### PR TITLE
 Implementa CRUD de TipoPregunta

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,10 @@
 import express from 'express';
+import cors from 'cors';
+
 import { testConnection } from './src/core/db/mysl/connection';
+import { requestLogger } from './src/core/middleware/requestLogger';
+import { errorHandler } from './src/core/middleware/errorHandler';
+import typeQuestionRoutes from './src/typeQuestion/infrastructure/http/router/typeQuestionRoutes';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -7,13 +12,26 @@ const port = process.env.PORT || 3000;
 async function startServer() {
     await testConnection();
     
+    // Middlewares
+    app.use(cors());
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    app.use(requestLogger);
+    
+    // Rutas
+    app.use('/api/tipo-pregunta', typeQuestionRoutes);
+
+    // Ruta raíz
     app.get('/', (_req, res) => {
         res.send('servidor iniciado');
     });
+    
+    // Manejo de errores (debe ir al final)
+    app.use(errorHandler);
 
     app.listen(port, () => {
         console.log('servidor corriendo en http://localhost:' + port);
-    })
+    });
 }
 
 startServer();

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -94,6 +94,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/dotenv": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
@@ -440,6 +450,19 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -666,6 +689,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "ideallyInert": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1109,6 +1148,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@types/dotenv": "^6.1.1",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
-        "mysql2": "^3.14.0",
+        "mysql2": "^3.15.3",
         "node-cron": "^3.0.3"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.5",
         "@types/node": "^24.10.0",
         "nodemon": "^3.1.10",
@@ -107,6 +109,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -457,6 +469,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -1143,6 +1168,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
   "homepage": "https://github.com/MarcosBrindis/sistemaEnvioCuestionarios#readme",
   "dependencies": {
     "@types/dotenv": "^6.1.1",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
-    "mysql2": "^3.14.0",
+    "mysql2": "^3.15.3",
     "node-cron": "^3.0.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.5",
     "@types/node": "^24.10.0",
     "nodemon": "^3.1.10",

--- a/src/core/middleware/errorHandler.ts
+++ b/src/core/middleware/errorHandler.ts
@@ -1,0 +1,82 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware para manejo de errores HTTP
+ * Funciones específicas para cada tipo de operación
+ */
+
+/**
+ * Maneja errores en operaciones GET
+ */
+export const handleGetError = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  console.error('Error en GET:', err.message);
+  
+  res.status(404).json({
+    error: {
+      status: '404',
+      title: 'Resource Not Found',
+      detail: err.message
+    }
+  });
+};
+
+/**
+ * Maneja errores en operaciones POST (crear)
+ */
+export const handlePostError = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  console.error('Error en POST:', err.message);
+  
+  res.status(400).json({
+    error: {
+      status: '400',
+      title: 'Bad Request',
+      detail: err.message
+    }
+  });
+};
+
+/**
+ * Maneja errores en operaciones PUT/PATCH (actualizar)
+ */
+export const handleUpdateError = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  console.error('Error en UPDATE:', err.message);
+  
+  res.status(400).json({
+    error: {
+      status: '400',
+      title: 'Bad Request', 
+      detail: err.message
+    }
+  });
+};
+
+/**
+ * Maneja errores en operaciones DELETE
+ */
+export const handleDeleteError = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  console.error('Error en DELETE:', err.message);
+  
+  res.status(400).json({
+    error: {
+      status: '400',
+      title: 'Bad Request',
+      detail: err.message
+    }
+  });
+};
+
+/**
+ * Manejador de errores genérico (para usar como fallback)
+ */
+export const errorHandler = (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
+  console.error('Error:', err.message);
+  
+  res.status(500).json({
+    error: {
+      status: '500',
+      title: 'Internal Server Error',
+      detail: err.message
+    }
+  });
+};
+

--- a/src/core/middleware/requestLogger.ts
+++ b/src/core/middleware/requestLogger.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware simple para logging de peticiones HTTP
+ * Imprime información básica de cada petición
+ */
+export const requestLogger = (req: Request, _res: Response, next: NextFunction): void => {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] ${req.method} ${req.originalUrl}`);
+  next();
+};
+

--- a/src/typeQuestion/application/usecase/CreateTypeQuestion.ts
+++ b/src/typeQuestion/application/usecase/CreateTypeQuestion.ts
@@ -1,0 +1,27 @@
+import { TypeQuestion } from '../../domain/model/typeQuestion';
+import { TypeQuestionRepository } from '../../domain/port/typeQuestionRepository';
+
+export class CreateTypeQuestion {
+  constructor(private repo: TypeQuestionRepository) {}
+
+  async execute(data: Omit<TypeQuestion, 'id' | 'creado_en' | 'actualizado_en'>): Promise<TypeQuestion> {
+    // Regla: El campo nombre es obligatorio y no puede ser nulo ni vacío
+    if (!data.nombre || typeof data.nombre !== 'string' || data.nombre.trim() === '') {
+      throw new Error('El campo nombre es obligatorio y no puede estar vacío');
+    }
+
+    const nombreNormalizado = data.nombre.trim();
+
+    // Regla: No se permite registrar más de un tipo de pregunta con el mismo nombre (case-insensitive)
+    const existingTypeQuestion = await this.repo.findByName(nombreNormalizado.toLowerCase());
+    if (existingTypeQuestion) {
+      throw new Error('Ya existe un tipo de pregunta con ese nombre');
+    }
+
+    // Crear el tipo de pregunta con el nombre normalizado
+    return this.repo.create({
+      ...data,
+      nombre: nombreNormalizado
+    });
+  }
+}

--- a/src/typeQuestion/application/usecase/DeleteTypeQuestion.ts
+++ b/src/typeQuestion/application/usecase/DeleteTypeQuestion.ts
@@ -1,0 +1,21 @@
+import { TypeQuestionRepository } from '../../domain/port/typeQuestionRepository';
+
+export class DeleteTypeQuestion {
+  constructor(private repo: TypeQuestionRepository) {}
+
+  async execute(id: number): Promise<void> {
+    // Verificar si el tipo de pregunta existe
+    const existingTypeQuestion = await this.repo.findById(id);
+    if (!existingTypeQuestion) {
+      throw new Error('El tipo de pregunta no existe');
+    }
+
+    // Regla: No se puede eliminar un tipo de pregunta si está asociado a alguna pregunta existente
+    const isAssociated = await this.repo.isAssociatedWithQuestions(id);
+    if (isAssociated) {
+      throw new Error('No se puede eliminar el tipo de pregunta porque está asociado a una o más preguntas');
+    }
+
+    await this.repo.delete(id);
+  }
+}

--- a/src/typeQuestion/application/usecase/GetTypeQuestion.ts
+++ b/src/typeQuestion/application/usecase/GetTypeQuestion.ts
@@ -1,0 +1,18 @@
+import { TypeQuestionRepository } from '../../domain/port/typeQuestionRepository';
+import { TypeQuestion } from '../../domain/model/typeQuestion';
+
+export class GetTypeQuestionById {
+  constructor(private repo: TypeQuestionRepository) {}
+
+  async execute(id: number): Promise<TypeQuestion | null> {
+    return this.repo.findById(id);
+  }
+}
+
+export class GetAllTypeQuestions {
+  constructor(private repo: TypeQuestionRepository) {}
+
+  async execute(): Promise<TypeQuestion[]> {
+    return this.repo.findAll();
+  }
+}

--- a/src/typeQuestion/application/usecase/UpdateTypeQuestion.ts
+++ b/src/typeQuestion/application/usecase/UpdateTypeQuestion.ts
@@ -1,0 +1,39 @@
+import { TypeQuestionRepository } from '../../domain/port/typeQuestionRepository';
+import { TypeQuestion } from '../../domain/model/typeQuestion';
+
+export class UpdateTypeQuestion {
+  constructor(private repo: TypeQuestionRepository) {}
+
+  async execute(id: number, data: Partial<TypeQuestion>): Promise<TypeQuestion> {
+    // Verificar si el tipo de pregunta existe
+    const existingTypeQuestion = await this.repo.findById(id);
+    if (!existingTypeQuestion) {
+      throw new Error('El tipo de pregunta no existe');
+    }
+
+    // Si se está actualizando el nombre, validar reglas de negocio
+    if (data.nombre) {
+      // Regla: El campo nombre no puede ser nulo ni vacío
+      if (typeof data.nombre !== 'string' || data.nombre.trim() === '') {
+        throw new Error('El campo nombre no puede estar vacío');
+      }
+
+      const nombreNormalizado = data.nombre.trim();
+
+      // Regla: No se permite registrar más de un tipo de pregunta con el mismo nombre (case-insensitive)
+      const duplicateTypeQuestion = await this.repo.findByName(nombreNormalizado.toLowerCase());
+      if (duplicateTypeQuestion && duplicateTypeQuestion.id_tipo_pregunta !== id) {
+        throw new Error('Ya existe un tipo de pregunta con ese nombre');
+      }
+
+      // Normalizar el nombre
+      data.nombre = nombreNormalizado;
+    }
+
+    await this.repo.update(id, data);
+    
+    // Retornar el tipo de pregunta actualizado
+    const updatedTypeQuestion = await this.repo.findById(id);
+    return updatedTypeQuestion!; // Ya verificamos que existe al inicio
+  }
+}

--- a/src/typeQuestion/domain/model/typeQuestion.ts
+++ b/src/typeQuestion/domain/model/typeQuestion.ts
@@ -1,0 +1,4 @@
+export interface TypeQuestion {
+  id_tipo_pregunta?: number; 
+  nombre: string;            
+}

--- a/src/typeQuestion/domain/port/typeQuestionRepository.ts
+++ b/src/typeQuestion/domain/port/typeQuestionRepository.ts
@@ -1,0 +1,11 @@
+import { TypeQuestion } from '../model/typeQuestion';
+
+export interface TypeQuestionRepository {
+  create(data: Omit<TypeQuestion, 'id' | 'creado_en' | 'actualizado_en'>): Promise<TypeQuestion>;
+  update(id: number, data: Partial<TypeQuestion>): Promise<void>;
+  delete(id: number): Promise<void>;
+  findById(id: number): Promise<TypeQuestion | null>;
+  findAll(): Promise<TypeQuestion[]>;
+  findByName(nombre: string): Promise<TypeQuestion | null>;
+  isAssociatedWithQuestions(id: number): Promise<boolean>;
+}

--- a/src/typeQuestion/infrastructure/database/mysql/BaseTypeQuestionRepository.ts
+++ b/src/typeQuestion/infrastructure/database/mysql/BaseTypeQuestionRepository.ts
@@ -1,0 +1,26 @@
+import { TypeQuestionRepository } from '../../../domain/port/typeQuestionRepository';
+import { TypeQuestion } from '../../../domain/model/typeQuestion';
+
+export abstract class BaseTypeQuestionRepository implements TypeQuestionRepository {
+  create(_data: Omit<TypeQuestion, 'id_tipo_pregunta'>): Promise<TypeQuestion> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  update(_id: number, _data: Partial<TypeQuestion>): Promise<void> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  delete(_id: number): Promise<void> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findById(_id: number): Promise<TypeQuestion | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findAll(): Promise<TypeQuestion[]> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findByName(_nombre: string): Promise<TypeQuestion | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  isAssociatedWithQuestions(_id: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+}

--- a/src/typeQuestion/infrastructure/database/mysql/TypeQuestionRepositoryMySQL.ts
+++ b/src/typeQuestion/infrastructure/database/mysql/TypeQuestionRepositoryMySQL.ts
@@ -1,0 +1,71 @@
+import { MysqlConnection } from '../../../../core/db/mysl/connection';
+import { BaseTypeQuestionRepository } from './BaseTypeQuestionRepository';
+import { TypeQuestion } from '../../../domain/model/typeQuestion';
+
+export class TypeQuestionRepositoryMySQL extends BaseTypeQuestionRepository {
+  async create(data: Omit<TypeQuestion, 'id_tipo_pregunta'>): Promise<TypeQuestion> {
+    const [result]: any = await MysqlConnection.execute(
+      `INSERT INTO tipo_Pregunta (nombre) VALUES (?)`,
+      [data.nombre]
+    );
+    const insertId = (result as any).insertId;
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM tipo_Pregunta WHERE id_tipo_pregunta = ?`,
+      [insertId]
+    );
+    return rows[0];
+  }
+
+async update(id: number, data: Partial<TypeQuestion>): Promise<void> {
+  const keys = Object.keys(data);
+  if (keys.length === 0) {
+    // No hay campos para actualizar, no hacer nada
+    return;
+  }
+  const fields = keys.map(key => `\`${key}\` = ?`).join(', ');
+  const values = Object.values(data);
+  await MysqlConnection.execute(
+    `UPDATE tipo_Pregunta SET ${fields} WHERE id_tipo_pregunta = ?`,
+    [...values, id]
+  );
+}
+
+  async delete(id: number): Promise<void> {
+    await MysqlConnection.execute(
+      `DELETE FROM tipo_Pregunta WHERE id_tipo_pregunta = ?`,
+      [id]
+    );
+  }
+
+  async findById(id: number): Promise<TypeQuestion | null> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM tipo_Pregunta WHERE id_tipo_pregunta = ?`,
+      [id]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async findAll(): Promise<TypeQuestion[]> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM tipo_Pregunta`
+    );
+    return rows;
+  }
+
+  async findByName(nombre: string): Promise<TypeQuestion | null> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM tipo_Pregunta WHERE LOWER(nombre) = LOWER(?)`,
+      [nombre]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+//mas adelante se usa
+  async isAssociatedWithQuestions(id: number): Promise<boolean> {
+    // Asumiendo que hay una tabla 'Pregunta' que referencia a 'TipoPregunta'
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT COUNT(*) as count FROM pregunta WHERE id_tipo_pregunta = ?`,
+      [id]
+    );
+    return rows[0].count > 0;
+  }
+}

--- a/src/typeQuestion/infrastructure/dependencies.ts
+++ b/src/typeQuestion/infrastructure/dependencies.ts
@@ -1,0 +1,16 @@
+import { CreateTypeQuestion } from '../application/usecase/CreateTypeQuestion';
+import { UpdateTypeQuestion } from '../application/usecase/UpdateTypeQuestion';
+import { DeleteTypeQuestion } from '../application/usecase/DeleteTypeQuestion';
+import { GetTypeQuestionById, GetAllTypeQuestions } from '../application/usecase/GetTypeQuestion';
+import { TypeQuestionRepositoryMySQL } from './database/mysql/TypeQuestionRepositoryMySQL';
+
+// Instancia del repositorio unificado
+const typeQuestionRepo = new TypeQuestionRepositoryMySQL();
+
+export const dependencies = {
+  createTypeQuestion: new CreateTypeQuestion(typeQuestionRepo),
+  updateTypeQuestion: new UpdateTypeQuestion(typeQuestionRepo),
+  deleteTypeQuestion: new DeleteTypeQuestion(typeQuestionRepo),
+  getTypeQuestionById: new GetTypeQuestionById(typeQuestionRepo),
+  getAllTypeQuestions: new GetAllTypeQuestions(typeQuestionRepo),
+};

--- a/src/typeQuestion/infrastructure/http/controller/createTypeQuestionController.ts
+++ b/src/typeQuestion/infrastructure/http/controller/createTypeQuestionController.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import { CreateTypeQuestion } from '../../../application/usecase/CreateTypeQuestion';
+import { handlePostError } from '../../../../core/middleware/errorHandler';
+
+export const createTypeQuestionController = (createTypeQuestion: CreateTypeQuestion) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.body.data || !req.body.data.attributes) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API'
+        }
+      });
+      return;
+    }
+
+    const { nombre } = req.body.data.attributes;
+    const typeQuestion = await createTypeQuestion.execute({ nombre });
+    
+    // Respuesta con formato JSON API
+    res.status(201).json({
+      data: {
+        type: 'tipos-pregunta',
+        id: typeQuestion.id_tipo_pregunta?.toString(),
+        attributes: {
+          nombre: typeQuestion.nombre
+        }
+      }
+    });
+  } catch (error) {
+    handlePostError(error as Error, req, res, next);
+  }
+};

--- a/src/typeQuestion/infrastructure/http/controller/deleteTypeQuestionController.ts
+++ b/src/typeQuestion/infrastructure/http/controller/deleteTypeQuestionController.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import { DeleteTypeQuestion } from '../../../application/usecase/DeleteTypeQuestion';
+import { handleDeleteError } from '../../../../core/middleware/errorHandler';
+
+export const deleteTypeQuestionController = (deleteTypeQuestion: DeleteTypeQuestion) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    await deleteTypeQuestion.execute(id);
+    
+    // Para DELETE exitoso, JSON API permite respuesta 204 sin cuerpo o 200 con meta información
+    res.status(204).send(); 
+  } catch (error) {
+    handleDeleteError(error as Error, req, res, next);
+  }
+};

--- a/src/typeQuestion/infrastructure/http/controller/getTypeQuestionsController.ts
+++ b/src/typeQuestion/infrastructure/http/controller/getTypeQuestionsController.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetTypeQuestionById, GetAllTypeQuestions } from '../../../application/usecase/GetTypeQuestion';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getTypeQuestionsController = (
+  getTypeQuestionById: GetTypeQuestionById,
+  getAllTypeQuestions: GetAllTypeQuestions
+) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { id } = req.params;
+    
+    // Si hay ID, buscar uno específico
+    if (id) {
+      const typeQuestion = await getTypeQuestionById.execute(Number(id));
+      
+      if (!typeQuestion) {
+        res.status(404).json({
+          error: {
+            status: '404',
+            title: 'Not Found',
+            detail: 'El tipo de pregunta no fue encontrado'
+          }
+        });
+        return;
+      }
+      
+      // Respuesta con formato JSON API para un recurso
+      res.status(200).json({
+        data: {
+          type: 'tipos-pregunta',
+          id: typeQuestion.id_tipo_pregunta?.toString(),
+          attributes: {
+            nombre: typeQuestion.nombre
+          }
+        }
+      });
+      return;
+    }
+    
+    // Si no hay ID, obtener todos
+    const typeQuestions = await getAllTypeQuestions.execute();
+    
+    // Respuesta con formato JSON API para colección
+    res.status(200).json({
+      data: typeQuestions.map(typeQuestion => ({
+        type: 'tipos-pregunta',
+        id: typeQuestion.id_tipo_pregunta?.toString(),
+        attributes: {
+          nombre: typeQuestion.nombre
+        }
+      }))
+    });
+  } catch (error) {
+    handleGetError(error as Error, req, res, next);
+  }
+};

--- a/src/typeQuestion/infrastructure/http/controller/updateTypeQuestionController.ts
+++ b/src/typeQuestion/infrastructure/http/controller/updateTypeQuestionController.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import { UpdateTypeQuestion } from '../../../application/usecase/UpdateTypeQuestion';
+import { handleUpdateError } from '../../../../core/middleware/errorHandler';
+
+export const updateTypeQuestionController = (updateTypeQuestion: UpdateTypeQuestion) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    // Validar estructura JSON API
+    if (!req.body.data || !req.body.data.attributes) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API'
+        }
+      });
+      return;
+    }
+
+    const id = Number(req.params.id);
+    const { nombre } = req.body.data.attributes;
+    const typeQuestion = await updateTypeQuestion.execute(id, { nombre });
+    
+    // Respuesta con formato JSON API
+    res.status(200).json({
+      data: {
+        type: 'tipos-pregunta',
+        id: typeQuestion.id_tipo_pregunta?.toString(),
+        attributes: {
+          nombre: typeQuestion.nombre
+        }
+      }
+    });
+  } catch (error) {
+    handleUpdateError(error as Error, req, res, next);
+  }
+};

--- a/src/typeQuestion/infrastructure/http/router/typeQuestionRoutes.ts
+++ b/src/typeQuestion/infrastructure/http/router/typeQuestionRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { dependencies } from '../../dependencies';
+import { createTypeQuestionController } from '../controller/createTypeQuestionController';
+import { updateTypeQuestionController } from '../controller/updateTypeQuestionController';
+import { deleteTypeQuestionController } from '../controller/deleteTypeQuestionController';
+import { getTypeQuestionsController } from '../controller/getTypeQuestionsController';
+
+const router = Router();
+
+// controladores
+const createTypeQuestion = createTypeQuestionController(dependencies.createTypeQuestion);
+const updateTypeQuestion = updateTypeQuestionController(dependencies.updateTypeQuestion);
+const deleteTypeQuestion = deleteTypeQuestionController(dependencies.deleteTypeQuestion);
+const getTypeQuestions = getTypeQuestionsController(dependencies.getTypeQuestionById, dependencies.getAllTypeQuestions);
+
+
+
+// Rutas 
+router.post('/', createTypeQuestion);
+router.get('/', getTypeQuestions);      
+router.get('/:id', getTypeQuestions); 
+router.patch('/:id', updateTypeQuestion);
+router.delete('/:id', deleteTypeQuestion);
+
+export default router;


### PR DESCRIPTION
Se implementaron los endpoints y la lógica necesaria para el manejo completo de Tipos de Pregunta. Ahora la API permite crear, consultar (uno o todos), actualizar y eliminar tipos de pregunta mediante los endpoints REST /api/tipo-pregunta. Se aplicaron reglas de negocio como la validación de unicidad del nombre (sin distinguir mayúsculas/minúsculas), obligatoriedad del campo nombre y restricción para eliminar tipos asociados a preguntas existentes. Las respuestas y solicitudes siguen el formato JSON API.