### PR TITLE
implementa CRUD de Opcion Preguntas

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { requestLogger } from './src/core/middleware/requestLogger';
 import { errorHandler } from './src/core/middleware/errorHandler';
 import typeQuestionRoutes from './src/typeQuestion/infrastructure/http/router/typeQuestionRoutes';
 import questionRoutes from './src/question/infrastructure/http/router/questionRoutes';
+import opcionPreguntaRoutes from './src/optionQuestion/infrastructure/http/router/opcionPreguntaRoutes';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -22,6 +23,7 @@ async function startServer() {
     // Rutas
     app.use('/api/tipo-pregunta', typeQuestionRoutes);
     app.use('/api/pregunta', questionRoutes);
+    app.use('/api/opcion-pregunta', opcionPreguntaRoutes);
 
     // Ruta raíz
     app.get('/', (_req, res) => {

--- a/src/optionQuestion/application/usecase/CreateOpcionPregunta.ts
+++ b/src/optionQuestion/application/usecase/CreateOpcionPregunta.ts
@@ -1,0 +1,71 @@
+import { OpcionPreguntaRepository } from '../../domain/port/opcionPreguntaRepository';
+import { OpcionPregunta } from '../../domain/model/opcionPregunta';
+
+export class CreateOpcionPregunta {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(data: Omit<OpcionPregunta, 'id_opcion_pregunta'>): Promise<OpcionPregunta> {
+    // Validaciones básicas de la opción
+    if (!data.texto_opcion || typeof data.texto_opcion !== 'string' || data.texto_opcion.trim() === '') {
+      throw new Error('El campo texto_opcion es obligatorio y no puede estar vacío');
+    }
+
+    if (!data.etiqueta || typeof data.etiqueta !== 'string' || data.etiqueta.trim() === '') {
+      throw new Error('El campo etiqueta es obligatorio y no puede estar vacío');
+    }
+
+    if (!data.id_pregunta || typeof data.id_pregunta !== 'number') {
+      throw new Error('El campo id_pregunta es obligatorio');
+    }
+
+    // Verificar que la pregunta existe
+    const questionExists = await this.repo.questionExists(data.id_pregunta);
+    if (!questionExists) {
+      throw new Error('La pregunta especificada no existe');
+    }
+
+    // Obtener el tipo de la pregunta para validar reglas de negocio
+    const questionType = await this.repo.getQuestionType(data.id_pregunta);
+    if (!questionType) {
+      throw new Error('No se pudo determinar el tipo de la pregunta');
+    }
+
+    // Validar regla: preguntas abiertas no pueden tener opciones
+    if (questionType === 'abierta') {
+      throw new Error('Las preguntas de tipo "abierta" no pueden tener opciones');
+    }
+
+    // Validar unicidad del texto dentro de la pregunta
+    const isTextUnique = await this.repo.isTextUniqueForQuestion(data.id_pregunta, data.texto_opcion.trim());
+    if (!isTextUnique) {
+      throw new Error('Ya existe una opción con el mismo texto para esta pregunta');
+    }
+
+    // Validar unicidad de la etiqueta dentro de la pregunta
+    const isLabelUnique = await this.repo.isLabelUniqueForQuestion(data.id_pregunta, data.etiqueta.trim());
+    if (!isLabelUnique) {
+      throw new Error('Ya existe una opción con la misma etiqueta para esta pregunta');
+    }
+
+    // Contar opciones existentes para validar reglas por tipo
+    const currentOptionsCount = await this.repo.countOptionsByQuestionId(data.id_pregunta);
+
+    // Validar reglas específicas por tipo de pregunta
+    if (questionType === 'boolean') {
+      if (currentOptionsCount >= 2) {
+        throw new Error('Las preguntas de tipo "boolean" pueden tener máximo 2 opciones');
+      }
+    }
+
+    // Crear la opción
+    const normalizedData = {
+      ...data,
+      texto_opcion: data.texto_opcion.trim(),
+      etiqueta: data.etiqueta.trim()
+    };
+
+    const createdOption = await this.repo.create(normalizedData);
+
+    return createdOption;
+  }
+}

--- a/src/optionQuestion/application/usecase/DeleteOpcionPregunta.ts
+++ b/src/optionQuestion/application/usecase/DeleteOpcionPregunta.ts
@@ -1,0 +1,33 @@
+import { OpcionPreguntaRepository } from '../../domain/port/opcionPreguntaRepository';
+
+export class DeleteOpcionPregunta {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(id: number): Promise<void> {
+    // Verificar si la opción existe
+    const existingOption = await this.repo.findById(id);
+    if (!existingOption) {
+      throw new Error('La opción de pregunta no existe');
+    }
+
+    // Obtener el tipo de pregunta para validar reglas de eliminación
+    const questionType = await this.repo.getQuestionType(existingOption.id_pregunta);
+    if (!questionType) {
+      throw new Error('No se pudo determinar el tipo de la pregunta asociada');
+    }
+
+    // Contar opciones existentes antes de eliminar
+    const currentOptionsCount = await this.repo.countOptionsByQuestionId(existingOption.id_pregunta);
+
+    // Validar reglas específicas por tipo de pregunta antes de eliminar
+    if (questionType === 'boolean' && currentOptionsCount <= 2) {
+      throw new Error('Las preguntas de tipo "boolean" deben tener exactamente 2 opciones. No se puede eliminar esta opción.');
+    }
+
+    if ((questionType === 'multiple' || questionType === 'opción múltiple') && currentOptionsCount <= 2) {
+      throw new Error('Las preguntas de tipo "multiple" deben tener al menos 2 opciones. No se puede eliminar esta opción.');
+    }
+
+    await this.repo.delete(id);
+  }
+}

--- a/src/optionQuestion/application/usecase/GetOpcionPregunta.ts
+++ b/src/optionQuestion/application/usecase/GetOpcionPregunta.ts
@@ -1,0 +1,26 @@
+import { OpcionPreguntaRepository } from '../../domain/port/opcionPreguntaRepository';
+import { OpcionPregunta } from '../../domain/model/opcionPregunta';
+
+export class GetOpcionPreguntaById {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(id: number): Promise<OpcionPregunta | null> {
+    return await this.repo.findById(id);
+  }
+}
+
+export class GetAllOpcionesPreguntas {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(): Promise<OpcionPregunta[]> {
+    return await this.repo.findAll();
+  }
+}
+
+export class GetOpcionPreguntasByQuestionId {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(idPregunta: number): Promise<OpcionPregunta[]> {
+    return await this.repo.findByQuestionId(idPregunta);
+  }
+}

--- a/src/optionQuestion/application/usecase/UpdateOpcionPregunta.ts
+++ b/src/optionQuestion/application/usecase/UpdateOpcionPregunta.ts
@@ -1,0 +1,104 @@
+import { OpcionPreguntaRepository } from '../../domain/port/opcionPreguntaRepository';
+import { OpcionPregunta } from '../../domain/model/opcionPregunta';
+
+export class UpdateOpcionPregunta {
+  constructor(private repo: OpcionPreguntaRepository) {}
+
+  async execute(id: number, data: Partial<OpcionPregunta>): Promise<OpcionPregunta> {
+    // Verificar si la opción existe
+    const existingOption = await this.repo.findById(id);
+    if (!existingOption) {
+      throw new Error('La opción de pregunta no existe');
+    }
+
+    // Si se está actualizando el texto_opcion, validar reglas de negocio
+    if (data.texto_opcion !== undefined) {
+      // Regla: El campo texto_opcion no puede ser nulo ni vacío
+      if (typeof data.texto_opcion !== 'string' || data.texto_opcion.trim() === '') {
+        throw new Error('El campo texto_opcion no puede estar vacío');
+      }
+
+      // Validar unicidad del texto dentro de la pregunta (excluyendo la opción actual)
+      const isTextUnique = await this.repo.isTextUniqueForQuestion(
+        existingOption.id_pregunta, 
+        data.texto_opcion.trim(), 
+        id
+      );
+      if (!isTextUnique) {
+        throw new Error('Ya existe una opción con el mismo texto para esta pregunta');
+      }
+      
+      data.texto_opcion = data.texto_opcion.trim();
+    }
+
+    // Si se está actualizando la etiqueta, validar unicidad
+    if (data.etiqueta !== undefined) {
+      if (typeof data.etiqueta !== 'string' || data.etiqueta.trim() === '') {
+        throw new Error('El campo etiqueta no puede estar vacío');
+      }
+
+      // Validar unicidad de la etiqueta dentro de la pregunta (excluyendo la opción actual)
+      const isLabelUnique = await this.repo.isLabelUniqueForQuestion(
+        existingOption.id_pregunta, 
+        data.etiqueta.trim(), 
+        id
+      );
+      if (!isLabelUnique) {
+        throw new Error('Ya existe una opción con la misma etiqueta para esta pregunta');
+      }
+      
+      data.etiqueta = data.etiqueta.trim();
+    }
+
+    // Si se está cambiando la pregunta asociada, validar reglas
+    if (data.id_pregunta !== undefined && data.id_pregunta !== existingOption.id_pregunta) {
+      // Verificar que la nueva pregunta existe
+      const questionExists = await this.repo.questionExists(data.id_pregunta);
+      if (!questionExists) {
+        throw new Error('La pregunta especificada no existe');
+      }
+
+      // Obtener el tipo de la nueva pregunta para validar reglas de negocio
+      const questionType = await this.repo.getQuestionType(data.id_pregunta);
+      if (!questionType) {
+        throw new Error('No se pudo determinar el tipo de la nueva pregunta');
+      }
+
+      // Validar regla: preguntas abiertas no pueden tener opciones
+      if (questionType === 'abierta') {
+        throw new Error('Las preguntas de tipo "abierta" no pueden tener opciones');
+      }
+
+      // Contar opciones existentes en la nueva pregunta para validar reglas por tipo
+      const currentOptionsCount = await this.repo.countOptionsByQuestionId(data.id_pregunta);
+
+      // Validar reglas específicas por tipo de pregunta
+      if (questionType === 'boolean') {
+        if (currentOptionsCount >= 2) {
+          throw new Error('Las preguntas de tipo "boolean" pueden tener máximo 2 opciones');
+        }
+      }
+
+      // Validar unicidad del texto en la nueva pregunta
+      if (data.texto_opcion || existingOption.texto_opcion) {
+        const textoToCheck = data.texto_opcion || existingOption.texto_opcion;
+        const isTextUniqueInNewQuestion = await this.repo.isTextUniqueForQuestion(data.id_pregunta, textoToCheck);
+        if (!isTextUniqueInNewQuestion) {
+          throw new Error('Ya existe una opción con el mismo texto en la pregunta de destino');
+        }
+      }
+
+      // Validar unicidad de la etiqueta en la nueva pregunta
+      if (data.etiqueta || existingOption.etiqueta) {
+        const etiquetaToCheck = data.etiqueta || existingOption.etiqueta;
+        const isLabelUniqueInNewQuestion = await this.repo.isLabelUniqueForQuestion(data.id_pregunta, etiquetaToCheck);
+        if (!isLabelUniqueInNewQuestion) {
+          throw new Error('Ya existe una opción con la misma etiqueta en la pregunta de destino');
+        }
+      }
+    }
+    
+    // Actualizar la opción
+    return await this.repo.update(id, data);
+  }
+}

--- a/src/optionQuestion/domain/model/opcionPregunta.ts
+++ b/src/optionQuestion/domain/model/opcionPregunta.ts
@@ -1,0 +1,6 @@
+export interface OpcionPregunta {
+  id_opcion_pregunta?: number;
+  texto_opcion: string;
+  etiqueta: string;
+  id_pregunta: number;
+}

--- a/src/optionQuestion/domain/port/opcionPreguntaRepository.ts
+++ b/src/optionQuestion/domain/port/opcionPreguntaRepository.ts
@@ -1,0 +1,17 @@
+import { OpcionPregunta } from '../model/opcionPregunta';
+
+export interface OpcionPreguntaRepository {
+  create(data: Omit<OpcionPregunta, 'id_opcion_pregunta'>): Promise<OpcionPregunta>;
+  update(id: number, data: Partial<OpcionPregunta>): Promise<OpcionPregunta>;
+  delete(id: number): Promise<void>;
+  findById(id: number): Promise<OpcionPregunta | null>;
+  findAll(): Promise<OpcionPregunta[]>;
+  findByQuestionId(idPregunta: number): Promise<OpcionPregunta[]>;
+  
+  // Métodos para validaciones de negocio
+  isTextUniqueForQuestion(idPregunta: number, textoOpcion: string, excludeId?: number): Promise<boolean>;
+  isLabelUniqueForQuestion(idPregunta: number, etiqueta: string, excludeId?: number): Promise<boolean>;
+  questionExists(idPregunta: number): Promise<boolean>;
+  getQuestionType(idPregunta: number): Promise<string | null>;
+  countOptionsByQuestionId(idPregunta: number): Promise<number>;
+}

--- a/src/optionQuestion/infrastructure/database/mysql/BaseOpcionPreguntaRepository.ts
+++ b/src/optionQuestion/infrastructure/database/mysql/BaseOpcionPreguntaRepository.ts
@@ -1,0 +1,40 @@
+import { OpcionPreguntaRepository } from '../../../domain/port/opcionPreguntaRepository';
+import { OpcionPregunta } from '../../../domain/model/opcionPregunta';
+
+export abstract class BaseOpcionPreguntaRepository implements OpcionPreguntaRepository {
+  create(_data: Omit<OpcionPregunta, 'id_opcion_pregunta'>): Promise<OpcionPregunta> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  update(_id: number, _data: Partial<OpcionPregunta>): Promise<OpcionPregunta> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  delete(_id: number): Promise<void> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findById(_id: number): Promise<OpcionPregunta | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findAll(): Promise<OpcionPregunta[]> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findByQuestionId(_idPregunta: number): Promise<OpcionPregunta[]> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  
+  // Métodos para validaciones de negocio
+  isTextUniqueForQuestion(_idPregunta: number, _textoOpcion: string, _excludeId?: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  isLabelUniqueForQuestion(_idPregunta: number, _etiqueta: string, _excludeId?: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  questionExists(_idPregunta: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  getQuestionType(_idPregunta: number): Promise<string | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  countOptionsByQuestionId(_idPregunta: number): Promise<number> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+}

--- a/src/optionQuestion/infrastructure/database/mysql/OpcionPreguntaRepositoryMySQL.ts
+++ b/src/optionQuestion/infrastructure/database/mysql/OpcionPreguntaRepositoryMySQL.ts
@@ -1,0 +1,126 @@
+import { MysqlConnection } from '../../../../core/db/mysl/connection';
+import { BaseOpcionPreguntaRepository } from './BaseOpcionPreguntaRepository';
+import { OpcionPregunta } from '../../../domain/model/opcionPregunta';
+
+export class OpcionPreguntaRepositoryMySQL extends BaseOpcionPreguntaRepository {
+  async create(data: Omit<OpcionPregunta, 'id_opcion_pregunta'>): Promise<OpcionPregunta> {
+    const [result]: any = await MysqlConnection.execute(
+      `INSERT INTO opcion_pregunta (texto_opcion, etiqueta, id_pregunta) VALUES (?, ?, ?)`,
+      [data.texto_opcion, data.etiqueta, data.id_pregunta]
+    );
+    const insertId = (result as any).insertId;
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM opcion_pregunta WHERE id_opcion_pregunta = ?`,
+      [insertId]
+    );
+    return rows[0];
+  }
+
+  async update(id: number, data: Partial<OpcionPregunta>): Promise<OpcionPregunta> {
+    const keys = Object.keys(data);
+    if (keys.length === 0) {
+      // No hay campos para actualizar, retornar la opción actual
+      const option = await this.findById(id);
+      return option!;
+    }
+    const fields = keys.map(key => `\`${key}\` = ?`).join(', ');
+    const values = Object.values(data);
+    await MysqlConnection.execute(
+      `UPDATE opcion_pregunta SET ${fields} WHERE id_opcion_pregunta = ?`,
+      [...values, id]
+    );
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM opcion_pregunta WHERE id_opcion_pregunta = ?`,
+      [id]
+    );
+    return rows[0];
+  }
+
+  async delete(id: number): Promise<void> {
+    await MysqlConnection.execute(
+      `DELETE FROM opcion_pregunta WHERE id_opcion_pregunta = ?`,
+      [id]
+    );
+  }
+
+  async findById(id: number): Promise<OpcionPregunta | null> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM opcion_pregunta WHERE id_opcion_pregunta = ?`,
+      [id]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async findAll(): Promise<OpcionPregunta[]> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM opcion_pregunta ORDER BY id_opcion_pregunta ASC`
+    );
+    return rows;
+  }
+
+  async findByQuestionId(idPregunta: number): Promise<OpcionPregunta[]> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT * FROM opcion_pregunta WHERE id_pregunta = ? ORDER BY id_opcion_pregunta ASC`,
+      [idPregunta]
+    );
+    return rows;
+  }
+
+  // Métodos para validaciones de negocio
+  async isTextUniqueForQuestion(idPregunta: number, textoOpcion: string, excludeId?: number): Promise<boolean> {
+    let query = `SELECT COUNT(*) as count FROM opcion_pregunta 
+                 WHERE id_pregunta = ? AND UPPER(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(texto_opcion, 'á', 'a'), 'é', 'e'), 'í', 'i'), 'ó', 'o'), 'ú', 'u')) = 
+                       UPPER(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(?, 'á', 'a'), 'é', 'e'), 'í', 'i'), 'ó', 'o'), 'ú', 'u'))`;
+    let params: any[] = [idPregunta, textoOpcion];
+    
+    if (excludeId !== undefined) {
+      query += ` AND id_opcion_pregunta != ?`;
+      params.push(excludeId);
+    }
+    
+    const [rows]: any = await MysqlConnection.execute(query, params);
+    return rows[0].count === 0;
+  }
+
+  async isLabelUniqueForQuestion(idPregunta: number, etiqueta: string, excludeId?: number): Promise<boolean> {
+    let query = `SELECT COUNT(*) as count FROM opcion_pregunta 
+                 WHERE id_pregunta = ? AND UPPER(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(etiqueta, 'á', 'a'), 'é', 'e'), 'í', 'i'), 'ó', 'o'), 'ú', 'u')) = 
+                       UPPER(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(?, 'á', 'a'), 'é', 'e'), 'í', 'i'), 'ó', 'o'), 'ú', 'u'))`;
+    let params: any[] = [idPregunta, etiqueta];
+    
+    if (excludeId !== undefined) {
+      query += ` AND id_opcion_pregunta != ?`;
+      params.push(excludeId);
+    }
+    
+    const [rows]: any = await MysqlConnection.execute(query, params);
+    return rows[0].count === 0;
+  }
+
+  async questionExists(idPregunta: number): Promise<boolean> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT COUNT(*) as count FROM pregunta WHERE id_pregunta = ?`,
+      [idPregunta]
+    );
+    return rows[0].count > 0;
+  }
+
+  async getQuestionType(idPregunta: number): Promise<string | null> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT tp.nombre 
+       FROM pregunta p 
+       INNER JOIN tipo_pregunta tp ON p.id_tipo_pregunta = tp.id_tipo_pregunta 
+       WHERE p.id_pregunta = ?`,
+      [idPregunta]
+    );
+    return rows.length > 0 ? rows[0].nombre : null;
+  }
+
+  async countOptionsByQuestionId(idPregunta: number): Promise<number> {
+    const [rows]: any = await MysqlConnection.execute(
+      `SELECT COUNT(*) as count FROM opcion_pregunta WHERE id_pregunta = ?`,
+      [idPregunta]
+    );
+    return rows[0].count;
+  }
+}

--- a/src/optionQuestion/infrastructure/dependencies.ts
+++ b/src/optionQuestion/infrastructure/dependencies.ts
@@ -1,0 +1,17 @@
+import { CreateOpcionPregunta } from '../application/usecase/CreateOpcionPregunta';
+import { UpdateOpcionPregunta } from '../application/usecase/UpdateOpcionPregunta';
+import { DeleteOpcionPregunta } from '../application/usecase/DeleteOpcionPregunta';
+import { GetOpcionPreguntaById, GetAllOpcionesPreguntas, GetOpcionPreguntasByQuestionId } from '../application/usecase/GetOpcionPregunta';
+import { OpcionPreguntaRepositoryMySQL } from './database/mysql/OpcionPreguntaRepositoryMySQL';
+
+// Instancia del repositorio
+const opcionPreguntaRepo = new OpcionPreguntaRepositoryMySQL();
+
+export const dependencies = {
+  createOpcionPregunta: new CreateOpcionPregunta(opcionPreguntaRepo),
+  updateOpcionPregunta: new UpdateOpcionPregunta(opcionPreguntaRepo),
+  deleteOpcionPregunta: new DeleteOpcionPregunta(opcionPreguntaRepo),
+  getOpcionPreguntaById: new GetOpcionPreguntaById(opcionPreguntaRepo),
+  getAllOpcionesPreguntas: new GetAllOpcionesPreguntas(opcionPreguntaRepo),
+  getOpcionPreguntasByQuestionId: new GetOpcionPreguntasByQuestionId(opcionPreguntaRepo),
+};

--- a/src/optionQuestion/infrastructure/http/controller/createOpcionPreguntaController.ts
+++ b/src/optionQuestion/infrastructure/http/controller/createOpcionPreguntaController.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express';
+import { CreateOpcionPregunta } from '../../../application/usecase/CreateOpcionPregunta';
+import { handlePostError } from '../../../../core/middleware/errorHandler';
+
+export const createOpcionPreguntaController = (createOpcionPregunta: CreateOpcionPregunta) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    // Validar estructura JSON API
+    if (!req.body.data || !req.body.data.attributes || !req.body.data.relationships) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API con relationships'
+        }
+      });
+      return;
+    }
+
+    // Extraer atributos - Soportar ambos formatos: kebab-case y snake_case
+    const texto_opcion = req.body.data.attributes['texto-opcion'] || req.body.data.attributes['texto_opcion'];
+    const etiqueta = req.body.data.attributes.etiqueta;
+    const id_pregunta = Number(req.body.data.relationships['pregunta']?.data?.id);
+
+    if (!id_pregunta) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El campo pregunta es obligatorio en relationships'
+        }
+      });
+      return;
+    }
+
+    // Crear la opción
+    const opcionPregunta = await createOpcionPregunta.execute({
+      texto_opcion,
+      etiqueta,
+      id_pregunta
+    });
+
+    // Respuesta en formato JSON API
+    res.status(201).json({
+      data: {
+        id: opcionPregunta.id_opcion_pregunta?.toString(),
+        type: 'opcion-pregunta',
+        attributes: {
+          'texto-opcion': opcionPregunta.texto_opcion,
+          etiqueta: opcionPregunta.etiqueta
+        },
+        relationships: {
+          pregunta: {
+            data: {
+              id: opcionPregunta.id_pregunta.toString(),
+              type: 'pregunta'
+            }
+          }
+        }
+      }
+    });
+
+  } catch (error: any) {
+    console.log('Error en CREATE opción:', error.message); // Debug
+    
+    if (error.message.includes('campo') || error.message.includes('obligatorio') || 
+        error.message.includes('vacío') || error.message.includes('existe')) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: error.message
+        }
+      });
+    } else if (error.message.includes('no existe') || error.message.includes('no se pudo')) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: error.message
+        }
+      });
+    } else if (error.message.includes('no pueden tener opciones') || error.message.includes('máximo') || 
+               error.message.includes('mismo texto') || error.message.includes('misma etiqueta')) {
+      res.status(409).json({
+        error: {
+          status: '409',
+          title: 'Conflict',
+          detail: error.message
+        }
+      });
+    } else {
+      // Usar el error handler del middleware
+      handlePostError(error, req, res, next);
+    }
+  }
+};

--- a/src/optionQuestion/infrastructure/http/controller/deleteOpcionPreguntaController.ts
+++ b/src/optionQuestion/infrastructure/http/controller/deleteOpcionPreguntaController.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from 'express';
+import { DeleteOpcionPregunta } from '../../../application/usecase/DeleteOpcionPregunta';
+import { handleDeleteError } from '../../../../core/middleware/errorHandler';
+
+export const deleteOpcionPreguntaController = (deleteOpcionPregunta: DeleteOpcionPregunta) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    
+    if (isNaN(id)) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'ID debe ser un número válido'
+        }
+      });
+      return;
+    }
+
+    await deleteOpcionPregunta.execute(id);
+
+    // Respuesta vacía con código 204 (No Content) según JSON API
+    res.status(204).send();
+
+  } catch (error: any) {
+    console.log('Error en DELETE opción:', error.message); // Debug
+    
+    if (error.message.includes('no existe')) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: error.message
+        }
+      });
+    } else if (error.message.includes('deben tener') || error.message.includes('al menos') || 
+               error.message.includes('exactamente') || error.message.includes('No se puede eliminar')) {
+      res.status(409).json({
+        error: {
+          status: '409',
+          title: 'Conflict',
+          detail: error.message
+        }
+      });
+    } else {
+      // Usar el error handler del middleware
+      handleDeleteError(error, req, res, next);
+    }
+  }
+};

--- a/src/optionQuestion/infrastructure/http/controller/getOpcionPreguntasController.ts
+++ b/src/optionQuestion/infrastructure/http/controller/getOpcionPreguntasController.ts
@@ -1,0 +1,127 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetOpcionPreguntaById, GetAllOpcionesPreguntas, GetOpcionPreguntasByQuestionId } from '../../../application/usecase/GetOpcionPregunta';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getOpcionPreguntasController = (
+  getOpcionPreguntaById: GetOpcionPreguntaById, 
+  getAllOpcionesPreguntas: GetAllOpcionesPreguntas,
+  getOpcionPreguntasByQuestionId: GetOpcionPreguntasByQuestionId
+) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const { preguntaId } = req.query; 
+
+    // Obtener por ID específico
+    if (id) {
+      const numId = Number(id);
+      if (isNaN(numId)) {
+        res.status(400).json({
+          error: {
+            status: '400',
+            title: 'Bad Request',
+            detail: 'ID debe ser un número válido'
+          }
+        });
+        return;
+      }
+
+      const opcionPregunta = await getOpcionPreguntaById.execute(numId);
+      
+      if (!opcionPregunta) {
+        res.status(404).json({
+          error: {
+            status: '404',
+            title: 'Not Found',
+            detail: 'Opción de pregunta no encontrada'
+          }
+        });
+        return;
+      }
+
+      res.status(200).json({
+        data: {
+          id: opcionPregunta.id_opcion_pregunta?.toString(),
+          type: 'opcion-pregunta',
+          attributes: {
+            'texto-opcion': opcionPregunta.texto_opcion,
+            etiqueta: opcionPregunta.etiqueta
+          },
+          relationships: {
+            pregunta: {
+              data: {
+                id: opcionPregunta.id_pregunta.toString(),
+                type: 'pregunta'
+              }
+            }
+          }
+        }
+      });
+      return;
+    }
+
+    // Filtrar por preguntaId si se proporciona
+    if (preguntaId) {
+      const numPreguntaId = Number(preguntaId);
+      if (isNaN(numPreguntaId)) {
+        res.status(400).json({
+          error: {
+            status: '400',
+            title: 'Bad Request',
+            detail: 'preguntaId debe ser un número válido'
+          }
+        });
+        return;
+      }
+
+      const opcionesPreguntas = await getOpcionPreguntasByQuestionId.execute(numPreguntaId);
+      
+      res.status(200).json({
+        data: opcionesPreguntas.map(opcionPregunta => ({
+          id: opcionPregunta.id_opcion_pregunta?.toString(),
+          type: 'opcion-pregunta',
+          attributes: {
+            'texto-opcion': opcionPregunta.texto_opcion,
+            etiqueta: opcionPregunta.etiqueta
+          },
+          relationships: {
+            pregunta: {
+              data: {
+                id: opcionPregunta.id_pregunta.toString(),
+                type: 'pregunta'
+              }
+            }
+          }
+        }))
+      });
+      return;
+    }
+
+    // Obtener todas las opciones de preguntas
+    const opcionesPreguntas = await getAllOpcionesPreguntas.execute();
+    
+    res.status(200).json({
+      data: opcionesPreguntas.map(opcionPregunta => ({
+        id: opcionPregunta.id_opcion_pregunta?.toString(),
+        type: 'opcion-pregunta',
+        attributes: {
+          'texto-opcion': opcionPregunta.texto_opcion,
+          etiqueta: opcionPregunta.etiqueta
+        },
+        relationships: {
+          pregunta: {
+            data: {
+              id: opcionPregunta.id_pregunta.toString(),
+              type: 'pregunta'
+            }
+          }
+        }
+      }))
+    });
+
+  } catch (error: any) {
+    console.log('Error en GET opciones:', error.message); // Debug
+    
+    // Usar el error handler del middleware
+    handleGetError(error, req, res, next);
+  }
+};

--- a/src/optionQuestion/infrastructure/http/controller/updateOpcionPreguntaController.ts
+++ b/src/optionQuestion/infrastructure/http/controller/updateOpcionPreguntaController.ts
@@ -1,0 +1,107 @@
+import { Request, Response, NextFunction } from 'express';
+import { UpdateOpcionPregunta } from '../../../application/usecase/UpdateOpcionPregunta';
+import { handleUpdateError } from '../../../../core/middleware/errorHandler';
+
+export const updateOpcionPreguntaController = (updateOpcionPregunta: UpdateOpcionPregunta) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    
+    if (isNaN(id)) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'ID debe ser un número válido'
+        }
+      });
+      return;
+    }
+
+    // Validar estructura JSON API
+    if (!req.body.data || !req.body.data.attributes) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API'
+        }
+      });
+      return;
+    }
+
+    const updateData: any = {};
+    
+    // Extraer atributos - Soportar ambos formatos: kebab-case y snake_case
+    if (req.body.data.attributes['texto-opcion'] !== undefined) {
+      updateData.texto_opcion = req.body.data.attributes['texto-opcion'];
+    } else if (req.body.data.attributes['texto_opcion'] !== undefined) {
+      updateData.texto_opcion = req.body.data.attributes['texto_opcion'];
+    }
+    
+    if (req.body.data.attributes.etiqueta !== undefined) {
+      updateData.etiqueta = req.body.data.attributes.etiqueta;
+    }
+
+    // Extraer relaciones si están presentes
+    if (req.body.data.relationships?.pregunta?.data?.id) {
+      updateData.id_pregunta = Number(req.body.data.relationships.pregunta.data.id);
+    }
+
+    // Actualizar la opción
+    const updatedOpcionPregunta = await updateOpcionPregunta.execute(id, updateData);
+
+    // Respuesta en formato JSON API
+    res.status(200).json({
+      data: {
+        id: updatedOpcionPregunta.id_opcion_pregunta?.toString(),
+        type: 'opcion-pregunta',
+        attributes: {
+          'texto-opcion': updatedOpcionPregunta.texto_opcion,
+          etiqueta: updatedOpcionPregunta.etiqueta
+        },
+        relationships: {
+          pregunta: {
+            data: {
+              id: updatedOpcionPregunta.id_pregunta.toString(),
+              type: 'pregunta'
+            }
+          }
+        }
+      }
+    });
+
+  } catch (error: any) {
+    console.log('Error en UPDATE opción:', error.message); // Debug
+    
+    if (error.message.includes('no existe')) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: error.message
+        }
+      });
+    } else if (error.message.includes('campo') || error.message.includes('obligatorio') || 
+               error.message.includes('vacío') || error.message.includes('existe')) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: error.message
+        }
+      });
+    } else if (error.message.includes('no pueden tener opciones') || error.message.includes('máximo') || 
+               error.message.includes('mismo texto') || error.message.includes('misma etiqueta')) {
+      res.status(409).json({
+        error: {
+          status: '409',
+          title: 'Conflict',
+          detail: error.message
+        }
+      });
+    } else {
+      // Usar el error handler del middleware
+      handleUpdateError(error, req, res, next);
+    }
+  }
+};

--- a/src/optionQuestion/infrastructure/http/router/opcionPreguntaRoutes.ts
+++ b/src/optionQuestion/infrastructure/http/router/opcionPreguntaRoutes.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { dependencies } from '../../dependencies';
+import { createOpcionPreguntaController } from '../controller/createOpcionPreguntaController';
+import { updateOpcionPreguntaController } from '../controller/updateOpcionPreguntaController';
+import { deleteOpcionPreguntaController } from '../controller/deleteOpcionPreguntaController';
+import { getOpcionPreguntasController } from '../controller/getOpcionPreguntasController';
+import { requestLogger } from '../../../../core/middleware/requestLogger';
+
+const router = Router();
+
+// Aplicar requestLogger a todas las rutas de opciones
+router.use(requestLogger);
+
+// Controladores
+const createOpcionPregunta = createOpcionPreguntaController(dependencies.createOpcionPregunta);
+const updateOpcionPregunta = updateOpcionPreguntaController(dependencies.updateOpcionPregunta);
+const deleteOpcionPregunta = deleteOpcionPreguntaController(dependencies.deleteOpcionPregunta);
+const getOpcionesPreguntas = getOpcionPreguntasController(
+  dependencies.getOpcionPreguntaById,
+  dependencies.getAllOpcionesPreguntas,
+  dependencies.getOpcionPreguntasByQuestionId
+);
+
+// Rutas 
+router.post('/', createOpcionPregunta);
+router.get('/', getOpcionesPreguntas);
+router.get('/:id', getOpcionesPreguntas);
+router.patch('/:id', updateOpcionPregunta);
+router.delete('/:id', deleteOpcionPregunta);
+
+export default router;


### PR DESCRIPTION
Este Pull Request incorpora la funcionalidad de CRUD para las opciones de pregunta dentro del sistema de cuestionarios. A partir de ahora es posible crear nuevas opciones ligadas a una pregunta, consultarlas de manera individual o por el identificador de la pregunta, actualizarlas y eliminarlas según sea necesario. Durante la implementación se añadieron reglas de negocio que garantizan la coherencia de los datos: no se permiten opciones duplicadas en texto ni en etiqueta dentro de la misma pregunta, cada opción debe estar asociada a una pregunta existente y las preguntas abiertas no pueden tener opciones. También se definieron restricciones específicas para los tipos de pregunta, de modo que las booleanas deben tener exactamente dos opciones y las múltiples al menos dos. Con estas validaciones se asegura que las opciones registradas sean consistentes y útiles para el flujo de cuestionarios, evitando errores comunes como textos vacíos o duplicados y fortaleciendo la integridad del sistema.