### PR TITLE
feat: modulo para crear templates de correos y tipos de correo

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,9 @@ import authRoutes from './src/auth/infrastructure/http/router/authRoutes';
 import importarMiembrosRoutes from './src/importacionMiembros/infrastructure/http/router/importarMiembrosRoutes';
 import suscripcionRoutes from './src/egresado-suscripcion/infrastructure/http/router/suscripcionRoutes';
 
+import tipoCorreoRoutes from './src/typesMail/infrastructure/http/router/tipoCorreoRoutes';
+import emailTemplateRouter from './src/emailTemplates/infrastructure/http/router/emailTemplateRouter';
+
 const app = express();
 const port = process.env.PORT || 3000;
 
@@ -29,8 +32,8 @@ async function startServer() {
         origin: true,
         credentials: true
     }));
-    app.use(express.json());
-    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json({ limit: '5mb' }));
+    app.use(express.urlencoded({ extended: true, limit: '5mb' }));
     app.use(requestLogger);
 
     const requiredSessionVars = [
@@ -70,6 +73,9 @@ async function startServer() {
     app.use('/api/auth', authRoutes);
     app.use('/api', importarMiembrosRoutes);
     app.use('/api', suscripcionRoutes);
+
+    app.use('/api', tipoCorreoRoutes);
+    app.use('/api/templates-correo', emailTemplateRouter);
 
     // Ruta raíz
     app.get('/', (_req, res) => {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -19,6 +19,38 @@ const options: swaggerJsdoc.Options = {
     ],
     components: {
       schemas: {
+        TipoCorreoAttributes: {
+          type: "object",
+          properties: {
+            tipo: { type: "string", example: "Encuesta de Satisfacción" }
+          }
+        },
+        TipoCorreoRequest: {
+          type: "object",
+          required: ["data"],
+          properties: {
+            data: {
+              type: "object",
+              properties: {
+                type: { type: "string", example: "tipos-correo" },
+                attributes: { $ref: "#/components/schemas/TipoCorreoAttributes" }
+              }
+            }
+          }
+        },
+        TipoCorreoResource: {
+          type: "object",
+          properties: {
+            data: {
+              type: "object",
+              properties: {
+                type: { type: "string", example: "tipos-correo" },
+                id: { type: "string", example: "1" },
+                attributes: { $ref: "#/components/schemas/TipoCorreoAttributes" }
+              }
+            }
+          }
+        },
         Egresado: {
           type: "object",
           properties: {
@@ -385,6 +417,57 @@ const options: swaggerJsdoc.Options = {
               },
             },
           },
+        },
+        EmailTemplate: {
+          type: "object",
+          properties: {
+            id: { type: "integer", example: 1 },
+            subject: { type: "string", example: "Welcome Email" },
+            body: { type: "string", example: "Hello, welcome!" },
+            typeId: { type: "integer", example: 2 },
+            createdAt: { type: "string", format: "date-time", example: "2024-01-01T12:00:00Z" },
+            updatedAt: { type: "string", format: "date-time", example: "2024-01-02T12:00:00Z" }
+          }
+        },
+        EmailTemplateInput: {
+          type: "object",
+          required: ["data"],
+          properties: {
+            data: {
+              type: "object",
+              required: ["type", "attributes", "relationships"],
+              properties: {
+                type: { type: "string", example: "templates-correo" },
+                attributes: {
+                  type: "object",
+                  required: ["asunto", "cuerpo"],
+                  properties: {
+                    asunto: { type: "string", example: "Encuesta de Seguimiento - Importante" },
+                    cuerpo: { type: "string", example: "<html><body><p>Hola {nombre}...</p></body></html>" }
+                  }
+                },
+                relationships: {
+                  type: "object",
+                  required: ["tipo_correo"],
+                  properties: {
+                    tipo_correo: {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "object",
+                          required: ["type", "id"],
+                          properties: {
+                            type: { type: "string", example: "tipo_correo" },
+                            id: { type: "string", example: "1" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
       },
     },

--- a/src/emailTemplates/application/usecase/CreateEmailTemplate.ts
+++ b/src/emailTemplates/application/usecase/CreateEmailTemplate.ts
@@ -1,0 +1,14 @@
+import { EmailTemplateRepository } from '../../domain/port/emailTemplateRepository';
+import { EmailTemplate } from '../../domain/model/emailTemplate';
+
+export class CreateEmailTemplate {
+  constructor(private repository: EmailTemplateRepository) {}
+
+  async execute(data: { subject: string; body: string; typeId: number }): Promise<EmailTemplate> {
+    if (!data.subject || !data.body || !data.typeId) {
+      throw new Error('subject, body, and typeId are required');
+    }
+    // Optionally: check for uniqueness of subject if needed
+    return this.repository.create({ subject: data.subject, body: data.body, typeId: data.typeId });
+  }
+}

--- a/src/emailTemplates/application/usecase/DeleteEmailTemplate.ts
+++ b/src/emailTemplates/application/usecase/DeleteEmailTemplate.ts
@@ -1,0 +1,14 @@
+import { EmailTemplateRepository } from '../../domain/port/emailTemplateRepository';
+
+export class DeleteEmailTemplate {
+  constructor(private repository: EmailTemplateRepository) {}
+
+  async execute(id: number): Promise<boolean> {
+    // Check if template is linked to a survey
+    const isLinked = await this.repository.isLinkedToSurvey(id);
+    if (isLinked) {
+      throw new Error('Cannot delete: template is linked to a survey');
+    }
+    return this.repository.delete(id);
+  }
+}

--- a/src/emailTemplates/application/usecase/GetEmailTemplateById.ts
+++ b/src/emailTemplates/application/usecase/GetEmailTemplateById.ts
@@ -1,0 +1,10 @@
+import { EmailTemplateRepository } from '../../domain/port/emailTemplateRepository';
+import { EmailTemplate } from '../../domain/model/emailTemplate';
+
+export class GetEmailTemplateById {
+  constructor(private repository: EmailTemplateRepository) {}
+
+  async execute(id: number): Promise<EmailTemplate | null> {
+    return this.repository.findById(id);
+  }
+}

--- a/src/emailTemplates/application/usecase/GetEmailTemplates.ts
+++ b/src/emailTemplates/application/usecase/GetEmailTemplates.ts
@@ -1,0 +1,10 @@
+import { EmailTemplateRepository } from '../../domain/port/emailTemplateRepository';
+import { EmailTemplate } from '../../domain/model/emailTemplate';
+
+export class GetEmailTemplates {
+  constructor(private repository: EmailTemplateRepository) {}
+
+  async execute(): Promise<EmailTemplate[]> {
+    return this.repository.findAll();
+  }
+}

--- a/src/emailTemplates/application/usecase/UpdateEmailTemplate.ts
+++ b/src/emailTemplates/application/usecase/UpdateEmailTemplate.ts
@@ -1,0 +1,13 @@
+import { EmailTemplateRepository } from '../../domain/port/emailTemplateRepository';
+import { EmailTemplate } from '../../domain/model/emailTemplate';
+
+export class UpdateEmailTemplate {
+  constructor(private repository: EmailTemplateRepository) {}
+
+  async execute(id: number, data: { subject: string; body: string; typeId: number }): Promise<EmailTemplate | null> {
+    if (!data.subject || !data.body || !data.typeId) {
+      throw new Error('subject, body, and typeId are required');
+    }
+    return this.repository.update(id, data);
+  }
+}

--- a/src/emailTemplates/domain/model/emailTemplate.ts
+++ b/src/emailTemplates/domain/model/emailTemplate.ts
@@ -1,0 +1,6 @@
+export interface EmailTemplate {
+  id: number;
+  subject: string;
+  body: string;
+  typeId: number;
+}

--- a/src/emailTemplates/domain/port/emailTemplateRepository.ts
+++ b/src/emailTemplates/domain/port/emailTemplateRepository.ts
@@ -1,0 +1,10 @@
+import { EmailTemplate } from '../model/emailTemplate';
+
+export interface EmailTemplateRepository {
+  findAll(): Promise<EmailTemplate[]>;
+  findById(id: number): Promise<EmailTemplate | null>;
+  create(template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate>;
+  update(id: number, template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate | null>;
+  delete(id: number): Promise<boolean>;
+  isLinkedToSurvey(id: number): Promise<boolean>;
+}

--- a/src/emailTemplates/infrastructure/database/mysql/EmailTemplateRepositoryMySQL.ts
+++ b/src/emailTemplates/infrastructure/database/mysql/EmailTemplateRepositoryMySQL.ts
@@ -1,0 +1,53 @@
+import { MysqlConnection } from '../../../../core/db/mysl/connection';
+import { BaseEmailTemplateRepository } from './baseEmailTemplateRepository';
+import { EmailTemplate } from '../../../domain/model/emailTemplate';
+
+export class EmailTemplateRepositoryMySQL extends BaseEmailTemplateRepository {
+  async findAll(): Promise<EmailTemplate[]> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT id_template AS id, asunto AS subject, cuerpo AS body, id_tipo_correo AS typeId FROM template_correo'
+    );
+    return rows;
+  }
+
+  async findById(id: number): Promise<EmailTemplate | null> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT id_template AS id, asunto AS subject, cuerpo AS body, id_tipo_correo AS typeId FROM template_correo WHERE id_template = ?',
+      [id]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async create(template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate> {
+    const [result]: any = await MysqlConnection.execute(
+      'INSERT INTO template_correo (asunto, cuerpo, id_tipo_correo) VALUES (?, ?, ?)',
+      [template.subject, template.body, template.typeId]
+    );
+    const insertId = result.insertId;
+    return this.findById(insertId) as Promise<EmailTemplate>;
+  }
+
+  async update(id: number, template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate | null> {
+    await MysqlConnection.execute(
+      'UPDATE template_correo SET asunto = ?, cuerpo = ?, id_tipo_correo = ? WHERE id_template = ?',
+      [template.subject, template.body, template.typeId, id]
+    );
+    return this.findById(id);
+  }
+
+  async delete(id: number): Promise<boolean> {
+    const [result]: any = await MysqlConnection.execute(
+      'DELETE FROM template_correo WHERE id_template = ?',
+      [id]
+    );
+    return result.affectedRows > 0;
+  }
+
+  async isLinkedToSurvey(id: number): Promise<boolean> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT COUNT(*) as count FROM encuesta WHERE id_template = ?',
+      [id]
+    );
+    return rows[0].count > 0;
+  }
+}

--- a/src/emailTemplates/infrastructure/database/mysql/baseEmailTemplateRepository.ts
+++ b/src/emailTemplates/infrastructure/database/mysql/baseEmailTemplateRepository.ts
@@ -1,0 +1,23 @@
+import { EmailTemplateRepository } from '../../../domain/port/emailTemplateRepository';
+import { EmailTemplate } from '../../../domain/model/emailTemplate';
+
+export abstract class BaseEmailTemplateRepository implements EmailTemplateRepository {
+  findAll(): Promise<EmailTemplate[]> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findById(_id: number): Promise<EmailTemplate | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  create(_template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  update(_id: number, _template: Omit<EmailTemplate, 'id'>): Promise<EmailTemplate | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  delete(_id: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  isLinkedToSurvey(_id: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+}

--- a/src/emailTemplates/infrastructure/dependencies.ts
+++ b/src/emailTemplates/infrastructure/dependencies.ts
@@ -1,0 +1,22 @@
+import { CreateEmailTemplate } from '../application/usecase/CreateEmailTemplate';
+import { GetEmailTemplates } from '../application/usecase/GetEmailTemplates';
+import { GetEmailTemplateById } from '../application/usecase/GetEmailTemplateById';
+import { UpdateEmailTemplate } from '../application/usecase/UpdateEmailTemplate';
+import { DeleteEmailTemplate } from '../application/usecase/DeleteEmailTemplate';
+import { EmailTemplateRepositoryMySQL } from './database/mysql/EmailTemplateRepositoryMySQL';
+
+const emailTemplateRepository = new EmailTemplateRepositoryMySQL();
+
+export const createEmailTemplate = new CreateEmailTemplate(emailTemplateRepository);
+export const getEmailTemplates = new GetEmailTemplates(emailTemplateRepository);
+export const getEmailTemplateById = new GetEmailTemplateById(emailTemplateRepository);
+export const updateEmailTemplate = new UpdateEmailTemplate(emailTemplateRepository);
+export const deleteEmailTemplate = new DeleteEmailTemplate(emailTemplateRepository);
+export const dependencies = {
+  createEmailTemplate,
+  getEmailTemplates,
+  getEmailTemplateById,
+  updateEmailTemplate,
+  deleteEmailTemplate,
+};
+

--- a/src/emailTemplates/infrastructure/http/controller/createEmailTemplateController.ts
+++ b/src/emailTemplates/infrastructure/http/controller/createEmailTemplateController.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import { CreateEmailTemplate } from '../../../application/usecase/CreateEmailTemplate';
+import { handlePostError } from '../../../../core/middleware/errorHandler';
+
+export const createEmailTemplateController = (createEmailTemplate: CreateEmailTemplate) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.body.data || !req.body.data.attributes || !req.body.data.relationships || !req.body.data.relationships.tipo_correo) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'The format must follow JSON:API specification'
+        }
+      });
+      return;
+    }
+    const { asunto, cuerpo } = req.body.data.attributes;
+    const typeId = Number(req.body.data.relationships.tipo_correo.data.id);
+    const template = await createEmailTemplate.execute({ subject: asunto, body: cuerpo, typeId });
+    res.status(201).json({
+      data: {
+        type: 'templates-correo',
+        id: template.id.toString(),
+        attributes: {
+          subject: template.subject,
+          body: template.body
+        },
+        relationships: {
+          tipo_correo: { data: { type: 'tipo_correo', id: template.typeId } }
+        }
+      }
+    });
+  } catch (error) {
+    handlePostError(error as Error, req, res, next);
+  }
+};

--- a/src/emailTemplates/infrastructure/http/controller/deleteEmailTemplateController.ts
+++ b/src/emailTemplates/infrastructure/http/controller/deleteEmailTemplateController.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+import { DeleteEmailTemplate } from '../../../application/usecase/DeleteEmailTemplate';
+import { handleDeleteError } from '../../../../core/middleware/errorHandler';
+
+export const deleteEmailTemplateController = (deleteEmailTemplate: DeleteEmailTemplate) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    await deleteEmailTemplate.execute(id);
+    res.status(204).send();
+  } catch (error) {
+    handleDeleteError(error as Error, req, res, next);
+  }
+};

--- a/src/emailTemplates/infrastructure/http/controller/getEmailTemplateByIdController.ts
+++ b/src/emailTemplates/infrastructure/http/controller/getEmailTemplateByIdController.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetEmailTemplateById } from '../../../application/usecase/GetEmailTemplateById';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getEmailTemplateByIdController = (getEmailTemplateById: GetEmailTemplateById) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    const template = await getEmailTemplateById.execute(id);
+    if (!template) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: 'Email template not found'
+        }
+      });
+      return;
+    }
+    res.status(200).json({
+      data: {
+        type: 'templates-correo',
+        id: template.id.toString(),
+        attributes: {
+          subject: template.subject,
+          body: template.body
+        },
+        relationships: {
+          tipo_correo: { data: { type: 'tipo_correo', id: template.typeId } }
+        }
+      }
+    });
+  } catch (error) {
+    handleGetError(error as Error, req, res, next);
+  }
+};

--- a/src/emailTemplates/infrastructure/http/controller/getEmailTemplatesController.ts
+++ b/src/emailTemplates/infrastructure/http/controller/getEmailTemplatesController.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetEmailTemplates } from '../../../application/usecase/GetEmailTemplates';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getEmailTemplatesController = (getEmailTemplates: GetEmailTemplates) => async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const templates = await getEmailTemplates.execute();
+    res.status(200).json({
+      data: templates.map(t => ({
+        type: 'templates-correo',
+        id: t.id.toString(),
+        attributes: {
+          subject: t.subject,
+          body: t.body
+        },
+        relationships: {
+          tipo_correo: { data: { type: 'tipo_correo', id: t.typeId } }
+        }
+      }))
+    });
+  } catch (error) {
+    handleGetError(error as Error, _req, res, next);
+  }
+};

--- a/src/emailTemplates/infrastructure/http/controller/updateEmailTemplateController.ts
+++ b/src/emailTemplates/infrastructure/http/controller/updateEmailTemplateController.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from 'express';
+import { UpdateEmailTemplate } from '../../../application/usecase/UpdateEmailTemplate';
+import { handleUpdateError } from '../../../../core/middleware/errorHandler';
+
+export const updateEmailTemplateController = (updateEmailTemplate: UpdateEmailTemplate) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    if (!req.body.data || !req.body.data.attributes || !req.body.data.relationships || !req.body.data.relationships.tipo_correo) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'The format must follow JSON:API specification'
+        }
+      });
+      return;
+    }
+    const id = Number(req.params.id);
+    const { asunto, cuerpo } = req.body.data.attributes;
+    const typeId = Number(req.body.data.relationships.tipo_correo.data.id);
+    const template = await updateEmailTemplate.execute(id, { subject: asunto, body: cuerpo, typeId });
+    if (!template) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: 'Email template not found'
+        }
+      });
+      return;
+    }
+    res.status(200).json({
+      data: {
+        type: 'templates-correo',
+        id: template.id.toString(),
+        attributes: {
+          subject: template.subject,
+          body: template.body
+        },
+        relationships: {
+          tipo_correo: { data: { type: 'tipo_correo', id: template.typeId } }
+        }
+      }
+    });
+  } catch (error) {
+    handleUpdateError(error as Error, req, res, next);
+  }
+};

--- a/src/emailTemplates/infrastructure/http/router/emailTemplateRouter.ts
+++ b/src/emailTemplates/infrastructure/http/router/emailTemplateRouter.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+
+import { createEmailTemplateController } from '../controller/createEmailTemplateController';
+import { getEmailTemplatesController } from '../controller/getEmailTemplatesController';
+import { getEmailTemplateByIdController } from '../controller/getEmailTemplateByIdController';
+import { updateEmailTemplateController } from '../controller/updateEmailTemplateController';
+import { deleteEmailTemplateController } from '../controller/deleteEmailTemplateController';
+import { createEmailTemplate, getEmailTemplates, getEmailTemplateById, updateEmailTemplate, deleteEmailTemplate } from '../../dependencies';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/templates-correo:
+ *   post:
+ *     summary: Create a new email template
+ *     tags: [EmailTemplates]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/EmailTemplateInput'
+ *     responses:
+ *       201:
+ *         description: Created
+ *       400:
+ *         description: Bad request
+ */
+router.post('/', createEmailTemplateController(createEmailTemplate));
+
+/**
+ * @swagger
+ * /api/templates-correo:
+ *   get:
+ *     summary: Get all email templates
+ *     tags: [EmailTemplates]
+ *     responses:
+ *       200:
+ *         description: List of email templates
+ */
+router.get('/', getEmailTemplatesController(getEmailTemplates));
+
+/**
+ * @swagger
+ * /api/templates-correo/{id}:
+ *   get:
+ *     summary: Get email template by ID
+ *     tags: [EmailTemplates]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Numeric ID of the template
+ *     responses:
+ *       200:
+ *         description: Email template found
+ *       404:
+ *         description: Not found
+ */
+router.get('/:id', getEmailTemplateByIdController(getEmailTemplateById));
+
+/**
+ * @swagger
+ * /api/templates-correo/{id}:
+ *   put:
+ *     summary: Update an email template
+ *     tags: [EmailTemplates]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Numeric ID of the template
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/EmailTemplateInput'
+ *     responses:
+ *       200:
+ *         description: Updated
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not found
+ */
+router.put('/:id', updateEmailTemplateController(updateEmailTemplate));
+
+/**
+ * @swagger
+ * /api/templates-correo/{id}:
+ *   delete:
+ *     summary: Delete an email template
+ *     tags: [EmailTemplates]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Numeric ID of the template
+ *     responses:
+ *       204:
+ *         description: Deleted
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not found or cannot delete
+ */
+router.delete('/:id', deleteEmailTemplateController(deleteEmailTemplate));
+
+export default router;

--- a/src/typesMail/application/usecase/CreateTipoCorreo.ts
+++ b/src/typesMail/application/usecase/CreateTipoCorreo.ts
@@ -1,0 +1,15 @@
+import { TipoCorreoRepository } from '../../domain/port/tipoCorreoRepository';
+
+export class CreateTipoCorreo {
+  constructor(private repo: TipoCorreoRepository) {}
+
+  async execute(tipo: string) {
+    if (!tipo || !tipo.trim()) {
+      throw new Error('El campo tipo es obligatorio');
+    }
+    if (await this.repo.existsByTipo(tipo)) {
+      throw new Error('El tipo de correo ya existe');
+    }
+    return this.repo.create(tipo.trim());
+  }
+}

--- a/src/typesMail/application/usecase/DeleteTipoCorreo.ts
+++ b/src/typesMail/application/usecase/DeleteTipoCorreo.ts
@@ -1,0 +1,13 @@
+import { TipoCorreoRepository } from '../../domain/port/tipoCorreoRepository';
+
+export class DeleteTipoCorreo {
+  constructor(private repo: TipoCorreoRepository) {}
+
+  async execute(id: number) {
+    if (await this.repo.isUsedInTemplates(id)) {
+      throw new Error('No se puede eliminar porque ya se usó en una plantilla');
+    }
+    await this.repo.delete(id);
+    return { eliminado: true };
+  }
+}

--- a/src/typesMail/application/usecase/GetTiposCorreo.ts
+++ b/src/typesMail/application/usecase/GetTiposCorreo.ts
@@ -1,0 +1,16 @@
+import { TipoCorreoRepository } from '../../domain/port/tipoCorreoRepository';
+
+
+export class GetTiposCorreo {
+  constructor(private repo: TipoCorreoRepository) {}
+  async execute() {
+    return this.repo.findAll();
+  }
+}
+
+export class GetTipoCorreoById {
+  constructor(private repo: TipoCorreoRepository) {}
+  async execute(id: number) {
+    return this.repo.findById(id);
+  }
+}

--- a/src/typesMail/application/usecase/UpdateTipoCorreo.ts
+++ b/src/typesMail/application/usecase/UpdateTipoCorreo.ts
@@ -1,0 +1,15 @@
+import { TipoCorreoRepository } from '../../domain/port/tipoCorreoRepository';
+
+export class UpdateTipoCorreo {
+  constructor(private repo: TipoCorreoRepository) {}
+
+  async execute(id: number, tipo: string) {
+    if (!tipo || !tipo.trim()) {
+      throw new Error('El campo tipo es obligatorio');
+    }
+    if (await this.repo.existsByTipo(tipo)) {
+      throw new Error('El tipo de correo ya existe');
+    }
+    return this.repo.update(id, tipo.trim());
+  }
+}

--- a/src/typesMail/domain/model/tipoCorreo.ts
+++ b/src/typesMail/domain/model/tipoCorreo.ts
@@ -1,0 +1,4 @@
+export interface TipoCorreo {
+  id_tipo_correo: number;
+  tipo: string;
+}

--- a/src/typesMail/domain/port/tipoCorreoRepository.ts
+++ b/src/typesMail/domain/port/tipoCorreoRepository.ts
@@ -1,0 +1,12 @@
+import { TipoCorreo } from '../model/tipoCorreo';
+
+
+export interface TipoCorreoRepository {
+  create(tipo: string): Promise<TipoCorreo>;
+  findAll(): Promise<TipoCorreo[]>;
+  findById(id: number): Promise<TipoCorreo | null>;
+  update(id: number, tipo: string): Promise<TipoCorreo>;
+  delete(id: number): Promise<void>;
+  existsByTipo(tipo: string): Promise<boolean>;
+  isUsedInTemplates(id: number): Promise<boolean>;
+}

--- a/src/typesMail/infrastructure/database/mysql/TipoCorreoRepositoryMySQL.ts
+++ b/src/typesMail/infrastructure/database/mysql/TipoCorreoRepositoryMySQL.ts
@@ -1,0 +1,62 @@
+import { MysqlConnection } from '../../../../core/db/mysl/connection';
+import { TipoCorreo } from '../../../domain/model/tipoCorreo';
+import { TipoCorreoRepository } from '../../../domain/port/tipoCorreoRepository';
+
+export class TipoCorreoRepositoryMySQL implements TipoCorreoRepository {
+    async findById(id: number): Promise<TipoCorreo | null> {
+      const [rows]: any = await MysqlConnection.execute(
+        'SELECT * FROM tipo_correo WHERE id_tipo_correo = ?',
+        [id]
+      );
+      if (rows.length === 0) return null;
+      return rows[0];
+    }
+  async create(tipo: string): Promise<TipoCorreo> {
+    const [result]: any = await MysqlConnection.execute(
+      'INSERT INTO tipo_correo (tipo) VALUES (?)',
+      [tipo]
+    );
+    return {
+      id_tipo_correo: result.insertId,
+      tipo
+    };
+  }
+
+  async findAll(): Promise<TipoCorreo[]> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT * FROM tipo_correo ORDER BY tipo'
+    );
+    return rows;
+  }
+
+  async update(id: number, tipo: string): Promise<TipoCorreo> {
+    await MysqlConnection.execute(
+      'UPDATE tipo_correo SET tipo = ? WHERE id_tipo_correo = ?',
+      [tipo, id]
+    );
+    return { id_tipo_correo: id, tipo };
+  }
+
+  async delete(id: number): Promise<void> {
+    await MysqlConnection.execute(
+      'DELETE FROM tipo_correo WHERE id_tipo_correo = ?',
+      [id]
+    );
+  }
+
+  async existsByTipo(tipo: string): Promise<boolean> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT COUNT(*) as count FROM tipo_correo WHERE tipo = ?',
+      [tipo]
+    );
+    return rows[0].count > 0;
+  }
+
+  async isUsedInTemplates(id: number): Promise<boolean> {
+    const [rows]: any = await MysqlConnection.execute(
+      'SELECT COUNT(*) as count FROM template_correo WHERE id_tipo_correo = ?',
+      [id]
+    );
+    return rows[0].count > 0;
+  }
+}

--- a/src/typesMail/infrastructure/dependencies.ts
+++ b/src/typesMail/infrastructure/dependencies.ts
@@ -1,0 +1,16 @@
+import { TipoCorreoRepositoryMySQL } from './database/mysql/TipoCorreoRepositoryMySQL';
+import { CreateTipoCorreo } from '../application/usecase/CreateTipoCorreo';
+import { GetTiposCorreo } from '../application/usecase/GetTiposCorreo';
+import { UpdateTipoCorreo } from '../application/usecase/UpdateTipoCorreo';
+import { DeleteTipoCorreo } from '../application/usecase/DeleteTipoCorreo';
+import { GetTipoCorreoById } from '../application/usecase/GetTiposCorreo';
+
+const tipoCorreoRepo = new TipoCorreoRepositoryMySQL();
+
+export const dependencies = {
+  createTipoCorreo: new CreateTipoCorreo(tipoCorreoRepo),
+  getTiposCorreo: new GetTiposCorreo(tipoCorreoRepo),
+  getTipoCorreoById: new GetTipoCorreoById(tipoCorreoRepo),
+  updateTipoCorreo: new UpdateTipoCorreo(tipoCorreoRepo),
+  deleteTipoCorreo: new DeleteTipoCorreo(tipoCorreoRepo),
+};

--- a/src/typesMail/infrastructure/http/controller/createTipoCorreoController.ts
+++ b/src/typesMail/infrastructure/http/controller/createTipoCorreoController.ts
@@ -1,0 +1,32 @@
+
+import { Request, Response, NextFunction } from 'express';
+import { CreateTipoCorreo } from '../../../application/usecase/CreateTipoCorreo';
+import { handlePostError } from '../../../../core/middleware/errorHandler';
+
+export const createTipoCorreoController = (createTipoCorreo: CreateTipoCorreo) => async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.data || !req.body.data.attributes) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API'
+        }
+      });
+      return;
+    }
+    const { tipo } = req.body.data.attributes;
+    const tipoCorreo = await createTipoCorreo.execute(tipo);
+    res.status(201).json({
+      data: {
+        type: 'tipos-correo',
+        id: tipoCorreo.id_tipo_correo?.toString(),
+        attributes: {
+          tipo: tipoCorreo.tipo
+        }
+      }
+    });
+  } catch (error) {
+    handlePostError(error as Error, req, res, next);
+  }
+};

--- a/src/typesMail/infrastructure/http/controller/deleteTipoCorreoController.ts
+++ b/src/typesMail/infrastructure/http/controller/deleteTipoCorreoController.ts
@@ -1,0 +1,14 @@
+
+import { Request, Response, NextFunction } from 'express';
+import { DeleteTipoCorreo } from '../../../application/usecase/DeleteTipoCorreo';
+import { handleDeleteError } from '../../../../core/middleware/errorHandler';
+
+export const deleteTipoCorreoController = (deleteTipoCorreo: DeleteTipoCorreo) => async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    await deleteTipoCorreo.execute(id);
+    res.status(204).send();
+  } catch (error) {
+    handleDeleteError(error as Error, req, res, next);
+  }
+};

--- a/src/typesMail/infrastructure/http/controller/getTipoCorreoByIdController.ts
+++ b/src/typesMail/infrastructure/http/controller/getTipoCorreoByIdController.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetTipoCorreoById } from '../../../application/usecase/GetTiposCorreo';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getTipoCorreoByIdController = (getTipoCorreoById: GetTipoCorreoById) => async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    const tipoCorreo = await getTipoCorreoById.execute(id);
+    if (!tipoCorreo) {
+      res.status(404).json({
+        error: {
+          status: '404',
+          title: 'Not Found',
+          detail: 'El tipo de correo no fue encontrado'
+        }
+      });
+      return;
+    }
+    res.status(200).json({
+      data: {
+        type: 'tipos-correo',
+        id: tipoCorreo.id_tipo_correo?.toString(),
+        attributes: {
+          tipo: tipoCorreo.tipo
+        }
+      }
+    });
+  } catch (error) {
+    handleGetError(error as Error, req, res, next);
+  }
+};

--- a/src/typesMail/infrastructure/http/controller/getTiposCorreoController.ts
+++ b/src/typesMail/infrastructure/http/controller/getTiposCorreoController.ts
@@ -1,0 +1,21 @@
+
+import { Request, Response, NextFunction } from 'express';
+import { GetTiposCorreo } from '../../../application/usecase/GetTiposCorreo';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getTiposCorreoController = (getTiposCorreo: GetTiposCorreo) => async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const tiposCorreo = await getTiposCorreo.execute();
+    res.status(200).json({
+      data: tiposCorreo.map((tipoCorreo: any) => ({
+        type: 'tipos-correo',
+        id: tipoCorreo.id_tipo_correo?.toString(),
+        attributes: {
+          tipo: tipoCorreo.tipo
+        }
+      }))
+    });
+  } catch (error) {
+    handleGetError(error as Error, _req, res, next);
+  }
+};

--- a/src/typesMail/infrastructure/http/controller/updateTipoCorreoController.ts
+++ b/src/typesMail/infrastructure/http/controller/updateTipoCorreoController.ts
@@ -1,0 +1,33 @@
+
+import { Request, Response, NextFunction } from 'express';
+import { UpdateTipoCorreo } from '../../../application/usecase/UpdateTipoCorreo';
+import { handleUpdateError } from '../../../../core/middleware/errorHandler';
+
+export const updateTipoCorreoController = (updateTipoCorreo: UpdateTipoCorreo) => async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.body.data || !req.body.data.attributes) {
+      res.status(400).json({
+        error: {
+          status: '400',
+          title: 'Bad Request',
+          detail: 'El formato debe seguir la especificación JSON API'
+        }
+      });
+      return;
+    }
+    const id = Number(req.params.id);
+    const { tipo } = req.body.data.attributes;
+    const tipoCorreo = await updateTipoCorreo.execute(id, tipo);
+    res.status(200).json({
+      data: {
+        type: 'tipos-correo',
+        id: tipoCorreo.id_tipo_correo?.toString(),
+        attributes: {
+          tipo: tipoCorreo.tipo
+        }
+      }
+    });
+  } catch (error) {
+    handleUpdateError(error as Error, req, res, next);
+  }
+};

--- a/src/typesMail/infrastructure/http/router/tipoCorreoRoutes.ts
+++ b/src/typesMail/infrastructure/http/router/tipoCorreoRoutes.ts
@@ -1,0 +1,133 @@
+
+import { Router } from 'express';
+import { dependencies } from '../../dependencies';
+import { createTipoCorreoController } from '../controller/createTipoCorreoController';
+import { getTiposCorreoController } from '../controller/getTiposCorreoController';
+import { updateTipoCorreoController } from '../controller/updateTipoCorreoController';
+import { deleteTipoCorreoController } from '../controller/deleteTipoCorreoController';
+import { getTipoCorreoByIdController } from '../controller/getTipoCorreoByIdController';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/tipo-correo:
+ *   post:
+ *     tags:
+ *       - Tipos de Correo
+ *     summary: Crear un nuevo tipo de correo
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/TipoCorreoRequest'
+ *     responses:
+ *       201:
+ *         description: Tipo de correo creado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TipoCorreoResource'
+ *       400:
+ *         description: Error de formato JSON API
+ */
+router.post('/tipo-correo', createTipoCorreoController(dependencies.createTipoCorreo));
+
+/**
+ * @openapi
+ * /api/tipo-correo/{id}:
+ *   patch:
+ *     tags:
+ *       - Tipos de Correo
+ *     summary: Actualizar un tipo de correo existente
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/TipoCorreoRequest'
+ *     responses:
+ *       200:
+ *         description: Tipo de correo actualizado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TipoCorreoResource'
+ *       400:
+ *         description: Error de formato JSON API
+ */
+router.patch('/tipo-correo/:id', updateTipoCorreoController(dependencies.updateTipoCorreo));
+
+/**
+ * @openapi
+ * /api/tipo-correo/{id}:
+ *   delete:
+ *     tags:
+ *       - Tipos de Correo
+ *     summary: Eliminar un tipo de correo
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: Tipo de correo eliminado exitosamente
+ *       400:
+ *         description: No se puede eliminar el tipo de correo si está en uso
+ */
+router.delete('/tipo-correo/:id', deleteTipoCorreoController(dependencies.deleteTipoCorreo));
+
+/**
+ * @openapi
+ * /api/tipo-correo/{id}:
+ *   get:
+ *     tags:
+ *       - Tipos de Correo
+ *     summary: Obtener un tipo de correo por ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Tipo de correo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TipoCorreoResource'
+ *       404:
+ *         description: Tipo de correo no encontrado
+ */
+router.get('/tipo-correo/:id', getTipoCorreoByIdController(dependencies.getTipoCorreoById));
+
+/**
+ * @openapi
+ * /api/tipo-correo:
+ *   get:
+ *     tags:
+ *       - Tipos de Correo
+ *     summary: Obtener todos los tipos de correo
+ *     responses:
+ *       200:
+ *         description: Lista de tipos de correo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/TipoCorreoResource'
+ */
+router.get('/tipo-correo', getTiposCorreoController(dependencies.getTiposCorreo));
+
+export default router;


### PR DESCRIPTION
se hizo el modulo para recibir el témplate personalizado solo acepta HTML, ya que los servivios de correo actuales (Gmail, Outlook, etc ) solo leen HTML