### PR TITLE
feat: modulo encustas funcional con buscador

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import groupRoutes from './src/group/infrastructure/http/router/groupRoutes';
 import authRoutes from './src/auth/infrastructure/http/router/authRoutes';
 import importarMiembrosRoutes from './src/importacionMiembros/infrastructure/http/router/importarMiembrosRoutes';
 import suscripcionRoutes from './src/egresado-suscripcion/infrastructure/http/router/suscripcionRoutes';
+import Survey from './src/surveys/infrastructure/http/router/surveyRouter';
 
 import tipoCorreoRoutes from './src/typesMail/infrastructure/http/router/tipoCorreoRoutes';
 import emailTemplateRouter from './src/emailTemplates/infrastructure/http/router/emailTemplateRouter';
@@ -76,6 +77,8 @@ async function startServer() {
 
     app.use('/api', tipoCorreoRoutes);
     app.use('/api/templates-correo', emailTemplateRouter);
+
+    app.use('/api/encuestas', Survey);
 
     // Ruta raíz
     app.get('/', (_req, res) => {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -19,6 +19,127 @@ const options: swaggerJsdoc.Options = {
     ],
     components: {
       schemas: {
+                SurveyInput: {
+                  type: "object",
+                  required: ["data"],
+                  properties: {
+                    data: {
+                      type: "object",
+                      required: ["type", "attributes", "relationships"],
+                      properties: {
+                        type: { type: "string", example: "encuestas" },
+                        attributes: {
+                          type: "object",
+                          required: ["nombre", "descripcion", "is_active"],
+                          properties: {
+                            nombre: { type: "string", example: "Encuesta Clima 2025" },
+                            descripcion: { type: "string", example: "Encuesta para medir el clima laboral" },
+                            is_active: { type: "boolean", example: true }
+                          }
+                        },
+                        relationships: {
+                          type: "object",
+                          required: ["formulario", "template-correo"],
+                          properties: {
+                            formulario: {
+                              type: "object",
+                              properties: {
+                                data: {
+                                  type: "object",
+                                  required: ["type", "id"],
+                                  properties: {
+                                    type: { type: "string", example: "formularios" },
+                                    id: { type: "string", example: "10" }
+                                  }
+                                }
+                              }
+                            },
+                            "template-correo": {
+                              type: "object",
+                              properties: {
+                                data: {
+                                  type: "object",
+                                  required: ["type", "id"],
+                                  properties: {
+                                    type: { type: "string", example: "templates-correo" },
+                                    id: { type: "string", example: "5" }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                SurveyResource: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "object",
+                      properties: {
+                        type: { type: "string", example: "encuestas" },
+                        id: { type: "string", example: "1" },
+                        attributes: {
+                          type: "object",
+                          properties: {
+                            nombre: { type: "string", example: "Encuesta Clima 2025" },
+                            descripcion: { type: "string", example: "Encuesta para medir el clima laboral" },
+                            is_active: { type: "boolean", example: true }
+                          }
+                        },
+                        relationships: {
+                          type: "object",
+                          properties: {
+                            formulario: {
+                              type: "object",
+                              properties: {
+                                data: {
+                                  type: "object",
+                                  properties: {
+                                    type: { type: "string", example: "formularios" },
+                                    id: { type: "string", example: "10" }
+                                  }
+                                }
+                              }
+                            },
+                            "template-correo": {
+                              type: "object",
+                              properties: {
+                                data: {
+                                  type: "object",
+                                  properties: {
+                                    type: { type: "string", example: "templates-correo" },
+                                    id: { type: "string", example: "5" }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                SurveyListResponse: {
+                  type: "object",
+                  properties: {
+                    meta: {
+                      type: "object",
+                      properties: {
+                        total_records: { type: "integer", example: 50 },
+                        total_pages: { type: "integer", example: 5 },
+                        current_page: { type: "integer", example: 1 },
+                        limit: { type: "integer", example: 10 }
+                      }
+                    },
+                    data: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/SurveyResource" }
+                    }
+                  }
+                },
         TipoCorreoAttributes: {
           type: "object",
           properties: {

--- a/src/surveys/application/usecase/CreateSurvey.ts
+++ b/src/surveys/application/usecase/CreateSurvey.ts
@@ -1,0 +1,17 @@
+import { SurveyRepository } from '../../domain/port/surveyRepository';
+import { Survey } from '../../domain/model/survey';
+
+export class CreateSurvey {
+  constructor(private repository: SurveyRepository) {}
+
+  async execute(data: Omit<Survey, 'id' | 'createdAt'>): Promise<Survey> {
+    if (!data.name || !data.formId || !data.templateId) {
+      throw new Error('Name, formId, and templateId are required');
+    }
+    const exists = await this.repository.existsActiveByName(data.name);
+    if (exists) {
+      throw new Error('An active survey with this name already exists');
+    }
+    return this.repository.create(data);
+  }
+}

--- a/src/surveys/application/usecase/DeleteSurvey.ts
+++ b/src/surveys/application/usecase/DeleteSurvey.ts
@@ -1,0 +1,9 @@
+import { SurveyRepository } from '../../domain/port/surveyRepository';
+
+export class DeleteSurvey {
+  constructor(private repository: SurveyRepository) {}
+
+  async execute(id: number): Promise<'deleted' | 'deactivated'> {
+    return this.repository.delete(id);
+  }
+}

--- a/src/surveys/application/usecase/GetSurveyById.ts
+++ b/src/surveys/application/usecase/GetSurveyById.ts
@@ -1,0 +1,10 @@
+import { SurveyRepository } from '../../domain/port/surveyRepository';
+import { Survey } from '../../domain/model/survey';
+
+export class GetSurveyById {
+  constructor(private repository: SurveyRepository) {}
+
+  async execute(id: number): Promise<Survey | null> {
+    return this.repository.findById(id);
+  }
+}

--- a/src/surveys/application/usecase/GetSurveys.ts
+++ b/src/surveys/application/usecase/GetSurveys.ts
@@ -1,0 +1,10 @@
+import { SurveyRepository } from '../../domain/port/surveyRepository';
+import { Survey } from '../../domain/model/survey';
+
+export class GetSurveys {
+  constructor(private repository: SurveyRepository) {}
+
+  async execute(params: { page?: number; limit?: number; isActive?: boolean; search?: string }): Promise<{ meta: any; data: Survey[] }> {
+    return this.repository.findAll(params);
+  }
+}

--- a/src/surveys/application/usecase/UpdateSurvey.ts
+++ b/src/surveys/application/usecase/UpdateSurvey.ts
@@ -1,0 +1,16 @@
+import { SurveyRepository } from '../../domain/port/surveyRepository';
+import { Survey } from '../../domain/model/survey';
+
+export class UpdateSurvey {
+  constructor(private repository: SurveyRepository) {}
+
+  async execute(id: number, data: Partial<Omit<Survey, 'id' | 'createdAt'>>): Promise<Survey | null> {
+    if (data.formId) {
+      const canChange = await this.repository.canChangeForm(id);
+      if (!canChange) {
+        throw new Error('Cannot change form: survey already has responses');
+      }
+    }
+    return this.repository.update(id, data);
+  }
+}

--- a/src/surveys/domain/model/survey.ts
+++ b/src/surveys/domain/model/survey.ts
@@ -1,0 +1,9 @@
+export interface Survey {
+  id: number;
+  name: string;
+  description: string;
+  createdAt: Date;
+  isActive: boolean;
+  formId: number;
+  templateId: number;
+}

--- a/src/surveys/domain/port/surveyRepository.ts
+++ b/src/surveys/domain/port/surveyRepository.ts
@@ -1,0 +1,17 @@
+import { Survey } from '../model/survey';
+
+export interface SurveyRepository {
+  findAll(params: {
+    page?: number;
+    limit?: number;
+    isActive?: boolean;
+    search?: string;
+  }): Promise<{ meta: any; data: Survey[] }>;
+  findById(id: number): Promise<Survey | null>;
+  create(survey: Omit<Survey, 'id' | 'createdAt'>): Promise<Survey>;
+  update(id: number, data: Partial<Omit<Survey, 'id' | 'createdAt'>>): Promise<Survey | null>;
+  delete(id: number): Promise<'deleted' | 'deactivated'>;
+  existsActiveByName(name: string): Promise<boolean>;
+  hasResponses(id: number): Promise<boolean>;
+  canChangeForm(id: number): Promise<boolean>;
+}

--- a/src/surveys/infrastructure/database/mysql/BaseSurveyRepository.ts
+++ b/src/surveys/infrastructure/database/mysql/BaseSurveyRepository.ts
@@ -1,0 +1,29 @@
+import { SurveyRepository } from '../../../domain/port/surveyRepository';
+import { Survey } from '../../../domain/model/survey';
+
+export abstract class BaseSurveyRepository implements SurveyRepository {
+  findAll(_params: any): Promise<{ meta: any; data: Survey[] }> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  findById(_id: number): Promise<Survey | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  create(_survey: Omit<Survey, 'id' | 'createdAt'>): Promise<Survey> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  update(_id: number, _data: Partial<Omit<Survey, 'id' | 'createdAt'>>): Promise<Survey | null> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  delete(_id: number): Promise<'deleted' | 'deactivated'> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  existsActiveByName(_name: string): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  hasResponses(_id: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+  canChangeForm(_id: number): Promise<boolean> {
+    return Promise.reject(new Error('Method not implemented'));
+  }
+}

--- a/src/surveys/infrastructure/database/mysql/SurveyRepositoryMySQL.ts
+++ b/src/surveys/infrastructure/database/mysql/SurveyRepositoryMySQL.ts
@@ -1,0 +1,141 @@
+import { MysqlConnection } from '../../../../core/db/mysl/connection';
+import { BaseSurveyRepository } from './BaseSurveyRepository';
+import { Survey } from '../../../domain/model/survey';
+
+export class SurveyRepositoryMySQL extends BaseSurveyRepository {
+  async findAll(params: {
+    page?: number;
+    limit?: number;
+    isActive?: boolean;
+    search?: string;
+  }): Promise<{ meta: any; data: Survey[] }> {
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 10;
+    const offset = (page - 1) * limit;
+    let where: string[] = [];
+    let values: any[] = [];
+    if (typeof params.isActive === 'boolean') {
+      where.push('is_active = ?');
+      values.push(params.isActive ? 1 : 0);
+    }
+    if (params.search) {
+      where.push('(nombre LIKE ? OR descripcion LIKE ?)');
+      values.push(`%${params.search}%`, `%${params.search}%`);
+    }
+    const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const [rows]: [any[], any] = await MysqlConnection.query(
+      `SELECT * FROM encuesta ${whereClause} ORDER BY fecha_creacion DESC LIMIT ? OFFSET ?`,
+      [...values, limit, offset]
+    );
+    const [countRows]: [any[], any] = await MysqlConnection.query(
+      `SELECT COUNT(*) as total FROM encuesta ${whereClause}`,
+      values
+    );
+    return {
+      meta: {
+        total_records: countRows[0]?.total ?? 0,
+        current_page: page,
+        total_pages: Math.ceil((countRows[0]?.total ?? 0) / limit),
+        limit,
+      },
+      data: rows.map(row => ({
+        id: row.id_encuesta,
+        name: row.nombre,
+        description: row.descripcion,
+        createdAt: row.fecha_creacion,
+        isActive: !!row.is_active,
+        formId: row.id_formulario,
+        templateId: row.id_template
+      })),
+    };
+  }
+
+  async findById(id: number): Promise<Survey | null> {
+    const [rows]: [any[], any] = await MysqlConnection.query('SELECT * FROM encuesta WHERE id_encuesta = ?', [id]);
+    if (!rows[0]) return null;
+    const row = rows[0];
+    // Mapear los campos de la base de datos al modelo Survey
+    return {
+      id: row.id_encuesta,
+      name: row.nombre,
+      description: row.descripcion,
+      createdAt: row.fecha_creacion,
+      isActive: !!row.is_active,
+      formId: row.id_formulario,
+      templateId: row.id_template
+    };
+  }
+
+  async create(survey: Omit<Survey, 'id' | 'createdAt'>): Promise<Survey> {
+    // Validación de nombre único activo
+    const exists = await this.existsActiveByName(survey.name);
+    if (exists) throw new Error('Ya existe una encuesta activa con ese nombre');
+    const [result]: any = await MysqlConnection.query(
+      'INSERT INTO encuesta (nombre, descripcion, is_active, id_formulario, id_template, fecha_creacion) VALUES (?, ?, ?, ?, ?, NOW())',
+      [survey.name, survey.description, survey.isActive ? 1 : 0, survey.formId, survey.templateId]
+    );
+    return this.findById(result.insertId) as Promise<Survey>;
+  }
+
+  async update(id: number, data: Partial<Omit<Survey, 'id' | 'createdAt'>>): Promise<Survey | null> {
+    // Restricción: Si la encuesta tiene respuestas, no se puede cambiar el formulario
+    if (data.formId !== undefined) {
+      const canChange = await this.canChangeForm(id);
+      if (!canChange) throw new Error('No se puede cambiar el formulario porque la encuesta tiene respuestas');
+    }
+    // Validación de nombre único activo (si cambia el nombre)
+    if (data.name) {
+      const [rows]: [any[], any] = await MysqlConnection.query(
+        'SELECT id_encuesta FROM encuesta WHERE nombre = ? AND is_active = 1 AND id_encuesta != ?',
+        [data.name, id]
+      );
+      if (rows.length > 0) throw new Error('Ya existe otra encuesta activa con ese nombre');
+    }
+    // Mapear los campos correctamente
+    const fieldMap: Record<string, string> = {
+      name: 'nombre',
+      description: 'descripcion',
+      isActive: 'is_active',
+      formId: 'id_formulario',
+      templateId: 'id_template'
+    };
+    const keys = Object.keys(data).filter(k => (data as any)[k] !== undefined);
+    if (keys.length === 0) return this.findById(id);
+    const fields = keys.map(k => `${fieldMap[k] || k} = ?`).join(', ');
+    const values = keys.map(k => (data as any)[k]);
+    await MysqlConnection.query(`UPDATE encuesta SET ${fields} WHERE id_encuesta = ?`, [...values, id]);
+    return this.findById(id);
+  }
+
+  async delete(id: number): Promise<'deleted' | 'deactivated'> {
+    // "Intelligent delete": Si tiene respuestas, desactivar; si no, eliminar
+    const hasResp = await this.hasResponses(id);
+    if (hasResp) {
+      await MysqlConnection.query('UPDATE encuesta SET is_active = 0 WHERE id_encuesta = ?', [id]);
+      return 'deactivated';
+    } else {
+      await MysqlConnection.query('DELETE FROM encuesta WHERE id_encuesta = ?', [id]);
+      return 'deleted';
+    }
+  }
+
+  async existsActiveByName(name: string): Promise<boolean> {
+    const [rows]: [any[], any] = await MysqlConnection.query('SELECT id_encuesta FROM encuesta WHERE nombre = ? AND is_active = 1', [name]);
+    return rows.length > 0;
+  }
+
+  async hasResponses(id: number): Promise<boolean> {
+    // Busca si hay respuestas asociadas al formulario de la encuesta
+    // Primero obtener el id_formulario de la encuesta
+    const [encRows]: [any[], any] = await MysqlConnection.query('SELECT id_formulario FROM encuesta WHERE id_encuesta = ?', [id]);
+    if (!encRows[0] || !encRows[0].id_formulario) return false;
+    const formId = encRows[0].id_formulario;
+    const [rows]: [any[], any] = await MysqlConnection.query('SELECT 1 FROM respuesta WHERE id_formulario = ? LIMIT 1', [formId]);
+    return rows.length > 0;
+  }
+
+  async canChangeForm(id: number): Promise<boolean> {
+    // Solo se puede cambiar el formulario si no hay respuestas
+    return !(await this.hasResponses(id));
+  }
+}

--- a/src/surveys/infrastructure/dependencies.ts
+++ b/src/surveys/infrastructure/dependencies.ts
@@ -1,0 +1,33 @@
+import { SurveyRepositoryMySQL } from './database/mysql/SurveyRepositoryMySQL';
+import { CreateSurvey } from '../application/usecase/CreateSurvey';
+import { GetSurveys } from '../application/usecase/GetSurveys';
+import { GetSurveyById } from '../application/usecase/GetSurveyById';
+import { UpdateSurvey } from '../application/usecase/UpdateSurvey';
+import { DeleteSurvey } from '../application/usecase/DeleteSurvey';
+import { createSurveyController } from './http/controller/createSurveyController';
+import { getSurveysController } from './http/controller/getSurveysController';
+import { getSurveyByIdController } from './http/controller/getSurveyByIdController';
+import { updateSurveyController } from './http/controller/updateSurveyController';
+import { deleteSurveyController } from './http/controller/deleteSurveyController';
+
+// Instancias
+const surveyRepository = new SurveyRepositoryMySQL();
+const createSurveyUseCase = new CreateSurvey(surveyRepository);
+const getSurveysUseCase = new GetSurveys(surveyRepository);
+const getSurveyByIdUseCase = new GetSurveyById(surveyRepository);
+const updateSurveyUseCase = new UpdateSurvey(surveyRepository);
+const deleteSurveyUseCase = new DeleteSurvey(surveyRepository);
+
+export {
+  surveyRepository,
+  createSurveyUseCase,
+  getSurveysUseCase,
+  getSurveyByIdUseCase,
+  updateSurveyUseCase,
+  deleteSurveyUseCase,
+  createSurveyController,
+  getSurveysController,
+  getSurveyByIdController,
+  updateSurveyController,
+  deleteSurveyController,
+};

--- a/src/surveys/infrastructure/http/controller/createSurveyController.ts
+++ b/src/surveys/infrastructure/http/controller/createSurveyController.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import { CreateSurvey } from '../../../application/usecase/CreateSurvey';
+import { handlePostError } from '../../../../core/middleware/errorHandler';
+
+export const createSurveyController = (createSurvey: CreateSurvey) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { data } = req.body;
+    if (!data || !data.attributes || !data.relationships) {
+      res.status(400).json({ error: { status: '400', title: 'Bad Request', detail: 'Formato JSON:API requerido' } });
+      return;
+    }
+    const { nombre, descripcion } = data.attributes;
+    const formId = Number(data.relationships.formulario.data.id);
+    const templateId = Number(data.relationships['template-correo'].data.id);
+    const survey = await createSurvey.execute({ name: nombre, description: descripcion, isActive: true, formId, templateId });
+    res.status(201).json({
+      data: {
+        type: 'encuestas',
+        id: survey.id.toString(),
+        attributes: {
+          nombre: survey.name,
+          descripcion: survey.description,
+          is_active: survey.isActive
+        },
+        relationships: {
+          formulario: { data: { type: 'formularios', id: survey.formId } },
+          'template-correo': { data: { type: 'templates-correo', id: survey.templateId } }
+        }
+      }
+    });
+  } catch (error) {
+    handlePostError(error as Error, req, res, next);
+  }
+};

--- a/src/surveys/infrastructure/http/controller/deleteSurveyController.ts
+++ b/src/surveys/infrastructure/http/controller/deleteSurveyController.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import { DeleteSurvey } from '../../../application/usecase/DeleteSurvey';
+import { handleDeleteError } from '../../../../core/middleware/errorHandler';
+
+export const deleteSurveyController = (deleteSurvey: DeleteSurvey) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    const result = await deleteSurvey.execute(id);
+    if (result === 'deleted') {
+      res.status(204).send();
+    } else {
+      res.status(200).json({ meta: { deactivated: true } });
+    }
+  } catch (error) {
+    handleDeleteError(error as Error, req, res, next);
+  }
+};

--- a/src/surveys/infrastructure/http/controller/getSurveyByIdController.ts
+++ b/src/surveys/infrastructure/http/controller/getSurveyByIdController.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetSurveyById } from '../../../application/usecase/GetSurveyById';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getSurveyByIdController = (getSurveyById: GetSurveyById) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    const survey = await getSurveyById.execute(id);
+    if (!survey) {
+      res.status(404).json({ error: { status: '404', title: 'Not Found', detail: 'Survey not found' } });
+      return;
+    }
+    res.status(200).json({ data: { type: 'encuestas', id: survey.id.toString(), attributes: { nombre: survey.name, descripcion: survey.description, is_active: survey.isActive }, relationships: { formulario: { data: { type: 'formularios', id: survey.formId } }, 'template-correo': { data: { type: 'templates-correo', id: survey.templateId } } } } });
+  } catch (error) {
+    handleGetError(error as Error, req, res, next);
+  }
+};

--- a/src/surveys/infrastructure/http/controller/getSurveysController.ts
+++ b/src/surveys/infrastructure/http/controller/getSurveysController.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import { GetSurveys } from '../../../application/usecase/GetSurveys';
+import { handleGetError } from '../../../../core/middleware/errorHandler';
+
+export const getSurveysController = (getSurveys: GetSurveys) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { page = 1, limit = 10, is_active, busqueda } = req.query;
+    const params: any = { page: Number(page), limit: Number(limit) };
+    if (is_active !== undefined) params.isActive = is_active === 'true';
+    if (busqueda) params.search = String(busqueda);
+    const result = await getSurveys.execute(params);
+    res.status(200).json({ meta: result.meta, data: result.data.map(survey => ({ type: 'encuestas', id: survey.id.toString(), attributes: { nombre: survey.name, descripcion: survey.description, is_active: survey.isActive }, relationships: { formulario: { data: { type: 'formularios', id: survey.formId } }, 'template-correo': { data: { type: 'templates-correo', id: survey.templateId } } } })) });
+  } catch (error) {
+    handleGetError(error as Error, req, res, next);
+  }
+};

--- a/src/surveys/infrastructure/http/controller/updateSurveyController.ts
+++ b/src/surveys/infrastructure/http/controller/updateSurveyController.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+import { UpdateSurvey } from '../../../application/usecase/UpdateSurvey';
+import { handleUpdateError } from '../../../../core/middleware/errorHandler';
+
+export const updateSurveyController = (updateSurvey: UpdateSurvey) => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+    const { data } = req.body;
+    if (!data || !data.attributes) {
+      res.status(400).json({ error: { status: '400', title: 'Bad Request', detail: 'Formato JSON:API requerido' } });
+      return;
+    }
+    const updateData: any = {};
+    if (data.attributes.nombre) updateData.name = data.attributes.nombre;
+    if (data.attributes.descripcion) updateData.description = data.attributes.descripcion;
+    if (typeof data.attributes.is_active === 'boolean') updateData.isActive = data.attributes.is_active;
+    if (data.relationships && data.relationships.formulario) updateData.formId = Number(data.relationships.formulario.data.id);
+    if (data.relationships && data.relationships['template-correo']) updateData.templateId = Number(data.relationships['template-correo'].data.id);
+    const survey = await updateSurvey.execute(id, updateData);
+    if (!survey) {
+      res.status(404).json({ error: { status: '404', title: 'Not Found', detail: 'Survey not found' } });
+      return;
+    }
+    res.status(200).json({ data: { type: 'encuestas', id: survey.id.toString(), attributes: { nombre: survey.name, descripcion: survey.description, is_active: survey.isActive }, relationships: { formulario: { data: { type: 'formularios', id: survey.formId } }, 'template-correo': { data: { type: 'templates-correo', id: survey.templateId } } } } });
+  } catch (error) {
+    handleUpdateError(error as Error, req, res, next);
+  }
+};

--- a/src/surveys/infrastructure/http/router/surveyRouter.ts
+++ b/src/surveys/infrastructure/http/router/surveyRouter.ts
@@ -1,0 +1,151 @@
+import { Router } from 'express';
+import { createSurveyController } from '../controller/createSurveyController';
+import { getSurveysController } from '../controller/getSurveysController';
+import { getSurveyByIdController } from '../controller/getSurveyByIdController';
+import { updateSurveyController } from '../controller/updateSurveyController';
+import { deleteSurveyController } from '../controller/deleteSurveyController';
+import { createSurveyUseCase, getSurveysUseCase, getSurveyByIdUseCase, updateSurveyUseCase, deleteSurveyUseCase } from '../../dependencies';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/encuestas:
+ *   post:
+ *     summary: Create a new survey
+ *     tags: [Surveys]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SurveyInput'
+ *     responses:
+ *       201:
+ *         description: Created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SurveyResource'
+ *       400:
+ *         description: Bad request
+ */
+router.post('/', createSurveyController(createSurveyUseCase));
+
+/**
+ * @swagger
+ * /api/encuestas:
+ *   get:
+ *     summary: Get all surveys (paginated, filtered)
+ *     tags: [Surveys]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *         description: Page number
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *         description: Records per page
+ *       - in: query
+ *         name: is_active
+ *         schema:
+ *           type: boolean
+ *         description: Filter by active status
+ *       - in: query
+ *         name: busqueda
+ *         schema:
+ *           type: string
+ *         description: Search by name
+ *     responses:
+ *       200:
+ *         description: List of surveys with pagination meta
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SurveyListResponse'
+ */
+router.get('/', getSurveysController(getSurveysUseCase));
+
+/**
+ * @swagger
+ * /api/encuestas/{id}:
+ *   get:
+ *     summary: Get survey by ID
+ *     tags: [Surveys]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Survey ID
+ *     responses:
+ *       200:
+ *         description: Survey found
+ *       404:
+ *         description: Not found
+ */
+router.get('/:id', getSurveyByIdController(getSurveyByIdUseCase));
+
+/**
+ * @swagger
+ * /api/encuestas/{id}:
+ *   patch:
+ *     summary: Update a survey
+ *     tags: [Surveys]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Survey ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SurveyInput'
+ *     responses:
+ *       200:
+ *         description: Updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SurveyResource'
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not found
+ */
+router.patch('/:id', updateSurveyController(updateSurveyUseCase));
+
+/**
+ * @swagger
+ * /api/encuestas/{id}:
+ *   delete:
+ *     summary: Delete survey (intelligent)
+ *     tags: [Surveys]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: Survey ID
+ *     responses:
+ *       204:
+ *         description: Deleted
+ *       200:
+ *         description: Deactivated
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not found
+ */
+router.delete('/:id', deleteSurveyController(deleteSurveyUseCase));
+
+export default router;


### PR DESCRIPTION
## Resumen
Se implementa el CRUD completo para el módulo de **Gestión de Encuestas**. Este módulo permite crear definiciones de encuestas vinculando un Formulario con un Template de correo, manejando reglas de negocio para la integridad de datos.

## Cambios Principales
- **Nuevos Endpoints:** Implementación de `POST`, `GET`, `PATCH` y `DELETE` para `/encuestas`.
- **Buscador y Paginación:** El endpoint `GET` ahora soporta `?page`, `?limit`, `?is_active` y `?busqueda` (filtro por nombre).
- **Formato de Respuesta:** Se estandarizó la salida usando **JSON:API**, incluyendo metadatos de paginación (`meta`).

## Reglas de Negocio Implementadas
1. **Unicidad:** Validación para evitar nombres duplicados en encuestas activas.
2. **Borrado Híbrido:**
   - Si no tiene respuestas: **Borrado Físico** (limpieza).
   - Si tiene respuestas: **Borrado Lógico** (`is_active = false`).
3. **Edición Segura:** Se bloquea el cambio de formulario si la encuesta ya tiene historial.
4. **Validación:** Se asegura que los IDs de formulario y template existan antes de guardar.

## Notas Adicionales
- Se utilizó `PATCH` en lugar de `PUT` para permitir la activación/desactivación rápida sin enviar todo el objeto.